### PR TITLE
Generic Code Distribution Aggregation

### DIFF
--- a/app/Hutch.Relay/Services/JobResultAggregators/GenericDistributionAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/GenericDistributionAggregator.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using System.Text.Json;
+using CsvHelper;
+using Hutch.Rackit.TaskApi;
+using Hutch.Rackit.TaskApi.Models;
+using Hutch.Relay.Models;
+
+namespace Hutch.Relay.Services.JobResultAggregators;
+
+public class GenericDistributionAggregator(IObfuscator obfuscator) : IQueryResultAggregator
+{
+  private static List<GenericDistributionRecord> ParseResultFile(string tsvData)
+  {
+    using var reader = new StringReader(tsvData);
+    using var tsv = new CsvReader(reader, CultureInfo.InvariantCulture);
+
+    return tsv.GetRecords<GenericDistributionRecord>().ToList();
+  }
+
+  public QueryResult Process(List<RelaySubTaskModel> subTasks)
+  {
+    // A Dictionary of aggregated results records keyed by Code
+    Dictionary<string, GenericDistributionRecord> aggregatedRecords = new();
+
+    // Aggregate across all valid subtasks
+    foreach (var subTask in subTasks)
+    {
+      if (subTask.Result is null) continue;
+
+      var result = JsonSerializer.Deserialize<JobResult>(subTask.Result);
+      // Don't crash if we can't parse the results;
+      // Today we just pretend like that downstream client didn't respond and skip it
+      // TODO: review this behaviour
+      if (result is null) continue;
+
+      // Find the relevant ResultFile (if none found, this subtask will not contribute results)
+      foreach (var file in result.Results.Files)
+      {
+        if (file.FileName != ResultFileName.CodeDistribution) continue;
+
+        var records = ParseResultFile(file.DecodeData());
+
+        aggregatedRecords.AccumulateData(records);
+      }
+    }
+
+    // Perform a final obfuscation pass of the now aggregated values as we convert them to a List for encoding
+    var finalData = aggregatedRecords
+      .Select(x =>
+        x.Value with
+        {
+          Count = obfuscator.Obfuscate(x.Value.Count)
+        })
+      .ToList();
+
+    // TODO: Review behaviour if no subtasks were valid:
+    // should we report failure Upstream instead of a 0 count?
+    if (!finalData.Any())
+      return new()
+      {
+        Count = 0,
+      };
+
+    return new()
+    {
+      Count = finalData.Count,
+      DatasetCount = 1,
+      Files =
+      [
+        new ResultFile
+          {
+            FileDescription = "code.distribution analysis results",
+          }
+          .WithAnalysisFileName(AnalysisType.Distribution, DistributionCode.Generic)
+          .WithData(finalData)
+      ]
+    };
+  }
+}
+
+file static class GenericDistributionAggregatorExtensions
+{
+  /// <summary>
+  /// Accumulates additional data from a list records into an ongoing aggregated results set
+  /// </summary>
+  /// <param name="accumulator">The results set we are accumulating the aggregated results into.</param>
+  /// <param name="records">The list of records to provide further data.</param>
+  /// <returns>The updated accumulated dataset.</returns>
+  public static void AccumulateData(
+    this Dictionary<string, GenericDistributionRecord> accumulator,
+    List<GenericDistributionRecord> records)
+  {
+    foreach (var record in records)
+    {
+      if (!accumulator.ContainsKey(record.Code))
+      {
+        // Create a brand new "base" record, inheriting most (but not all) from the current value
+        accumulator.Add(
+          record.Code,
+          record with
+          {
+            // Override Collection with the Upstream ID instead of Downstream
+            Collection = "none"
+          });
+      }
+      else
+      {
+        // Key was already present
+        // merge Count but otherwise keep the base Accumulator record's properties
+        accumulator[record.Code].Count += record.Count;
+      }
+    }
+  }
+}

--- a/app/Hutch.Relay/Services/JobResultAggregators/GenericDistributionAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/GenericDistributionAggregator.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using CsvHelper;
+using CsvHelper.Configuration;
 using Hutch.Rackit.TaskApi;
 using Hutch.Rackit.TaskApi.Models;
 using Hutch.Relay.Models;
@@ -11,16 +12,20 @@ public class GenericDistributionAggregator(IObfuscator obfuscator) : IQueryResul
 {
   private static List<GenericDistributionRecord> ParseResultFile(string tsvData)
   {
+    var config = CsvConfiguration.FromAttributes<GenericDistributionRecord>();
+    config.MissingFieldFound = null; // The model will initialise missing fields
+
     using var reader = new StringReader(tsvData);
-    using var tsv = new CsvReader(reader, CultureInfo.InvariantCulture);
+    using var tsv = new CsvReader(reader, config);
 
     return tsv.GetRecords<GenericDistributionRecord>().ToList();
   }
 
   public QueryResult Process(List<RelaySubTaskModel> subTasks)
   {
-    // A Dictionary of aggregated results records keyed by Code
-    Dictionary<string, GenericDistributionRecord> aggregatedRecords = new();
+    // Aggregation State
+    (string collectionId, Dictionary<string, GenericDistributionRecord> aggregatedRecords) accumulator =
+      (subTasks.FirstOrDefault()?.RelayTask.Collection ?? string.Empty, new());
 
     // Aggregate across all valid subtasks
     foreach (var subTask in subTasks)
@@ -33,19 +38,28 @@ public class GenericDistributionAggregator(IObfuscator obfuscator) : IQueryResul
       // TODO: review this behaviour
       if (result is null) continue;
 
+      // If the QueryResult says there's no data, jog on
+      if (result.Results.Count == 0) continue;
+
       // Find the relevant ResultFile (if none found, this subtask will not contribute results)
       foreach (var file in result.Results.Files)
       {
         if (file.FileName != ResultFileName.CodeDistribution) continue;
+        var rawFileData = file.DecodeData();
 
-        var records = ParseResultFile(file.DecodeData());
+        // Check we have more than just the header row; CsvHelper won't parse it if there's no actual data
+        // This could happen if the QueryResult.Count was a lie ;) or just if the file was populated weirdly
+        if (rawFileData.Split("\n").Length < 2) continue;
 
-        aggregatedRecords.AccumulateData(records);
+        // If we actually have data, go ahead and parse
+        var records = ParseResultFile(rawFileData);
+
+        accumulator.AccumulateData(records);
       }
     }
 
     // Perform a final obfuscation pass of the now aggregated values as we convert them to a List for encoding
-    var finalData = aggregatedRecords
+    var finalData = accumulator.aggregatedRecords
       .Select(x =>
         x.Value with
         {
@@ -87,27 +101,27 @@ file static class GenericDistributionAggregatorExtensions
   /// <param name="records">The list of records to provide further data.</param>
   /// <returns>The updated accumulated dataset.</returns>
   public static void AccumulateData(
-    this Dictionary<string, GenericDistributionRecord> accumulator,
+    this (string collectionId, Dictionary<string, GenericDistributionRecord> records) accumulator,
     List<GenericDistributionRecord> records)
   {
     foreach (var record in records)
     {
-      if (!accumulator.ContainsKey(record.Code))
+      if (!accumulator.records.TryGetValue(record.Code, out var accumulatorRecord))
       {
         // Create a brand new "base" record, inheriting most (but not all) from the current value
-        accumulator.Add(
+        accumulator.records.Add(
           record.Code,
           record with
           {
             // Override Collection with the Upstream ID instead of Downstream
-            Collection = "none"
+            Collection = accumulator.collectionId,
           });
       }
       else
       {
         // Key was already present
         // merge Count but otherwise keep the base Accumulator record's properties
-        accumulator[record.Code].Count += record.Count;
+        accumulatorRecord.Count += record.Count;
       }
     }
   }

--- a/app/Hutch.Relay/Services/RelayTaskService.cs
+++ b/app/Hutch.Relay/Services/RelayTaskService.cs
@@ -72,7 +72,7 @@ public class RelayTaskService(ApplicationDbContext db) : IRelayTaskService
                    .SingleOrDefaultAsync(t => t.Id == id)
                  ?? throw new KeyNotFoundException();
 
-    entity.CompletedAt = DateTimeOffset.Now;
+    entity.CompletedAt = DateTimeOffset.UtcNow;
 
     db.RelayTasks.Update(entity);
     await db.SaveChangesAsync();

--- a/app/Hutch.Relay/Services/ResultsService.cs
+++ b/app/Hutch.Relay/Services/ResultsService.cs
@@ -16,7 +16,10 @@ public class ResultsService(
   ITaskApiClient upstreamTasks,
   IRelayTaskService relayTaskService,
   [FromKeyedServices(nameof(AvailabilityAggregator))]
-  IQueryResultAggregator availabilityAggregator)
+  IQueryResultAggregator availabilityAggregator,
+  [FromKeyedServices(nameof(GenericDistributionAggregator))]
+  IQueryResultAggregator codeDistributionAggregator
+)
 {
   private readonly ApiClientOptions options = options.Value;
 
@@ -117,6 +120,7 @@ public class ResultsService(
     IQueryResultAggregator aggregator = relayTask.Type switch
     {
       TaskTypes.TaskApi_Availability => availabilityAggregator,
+      TaskTypes.TaskApi_CodeDistribution => codeDistributionAggregator,
       _ => throw new ArgumentOutOfRangeException(
         $"Relay tried to handle a Task Type it doesn't support Results Aggregation for: {relayTask.Type}")
     };

--- a/app/Hutch.Relay/Services/UpstreamTaskPoller.cs
+++ b/app/Hutch.Relay/Services/UpstreamTaskPoller.cs
@@ -90,7 +90,7 @@ public class UpstreamTaskPoller(
         var delayTime = TimeSpan.FromSeconds(5);
         // Swallow exceptions and just log; the while loop will restart polling
         logger.LogError(e,
-          "An error occurred handling '{TypeName}' tasks. Waiting {DelaySeconds} to retry.",
+          "An error occurred handling '{TypeName}' tasks. Waiting {DelaySeconds}s before resuming polling.",
           typeof(T).Name,
           Math.Floor(delayTime.TotalSeconds));
 

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -57,7 +57,9 @@ public static class ConfigureWebServices
       .AddTransient<IObfuscator, Obfuscator>();
     
     // Aggregators
-    builder.Services.AddKeyedTransient<IQueryResultAggregator,AvailabilityAggregator>(nameof(AvailabilityAggregator));
+    builder.Services
+      .AddKeyedTransient<IQueryResultAggregator,AvailabilityAggregator>(nameof(AvailabilityAggregator))
+      .AddKeyedTransient<IQueryResultAggregator,GenericDistributionAggregator>(nameof(GenericDistributionAggregator));
 
     // Hosted Services
     builder.Services.AddHostedService<BackgroundUpstreamTaskPoller>();

--- a/lib/Hutch.Rackit/TaskApi/Constants.cs
+++ b/lib/Hutch.Rackit/TaskApi/Constants.cs
@@ -20,6 +20,13 @@ public static class DistributionCode
   public const string Icd = "ICD-MAIN";
 }
 
+public static class ResultFileName
+{
+  public const string CodeDistribution = "code.distribution";
+
+  public const string DemographicsDistribution = "demographics.distribution";
+}
+
 public static class ResultResponseStatus
 {
   public const string Conflict = "CONFLICT";

--- a/lib/Hutch.Rackit/TaskApi/Models/DemographicsDistributionRecord.cs
+++ b/lib/Hutch.Rackit/TaskApi/Models/DemographicsDistributionRecord.cs
@@ -13,7 +13,7 @@ namespace Hutch.Rackit.TaskApi.Models;
 [CultureInfo("en")]
 [NewLine("\n")]
 [Encoding("utf-8")]
-public class DemographicsDistributionRecord : IResultFileRecord
+public record DemographicsDistributionRecord : IResultFileRecord
 {
   /// <summary>
   /// Collection ID representing the Biobank or Dataset these results are for

--- a/lib/Hutch.Rackit/TaskApi/Models/GenericDistributionRecord.cs
+++ b/lib/Hutch.Rackit/TaskApi/Models/GenericDistributionRecord.cs
@@ -13,7 +13,7 @@ namespace Hutch.Rackit.TaskApi.Models;
 [CultureInfo("en")]
 [NewLine("\n")]
 [Encoding("utf-8")]
-public class GenericDistributionRecord : IResultFileRecord
+public record GenericDistributionRecord : IResultFileRecord
 {
   /// <summary>
   /// Collection ID representing the Biobank or Dataset these results are for

--- a/lib/Hutch.Rackit/TaskApi/Models/ResultFile.cs
+++ b/lib/Hutch.Rackit/TaskApi/Models/ResultFile.cs
@@ -137,8 +137,8 @@ public static class ResultFileExtensions
     {
       AnalysisType.Distribution => analysisCode switch
       {
-        DistributionCode.Generic => "code.distribution",
-        DistributionCode.Demographics => "demographics.distribution",
+        DistributionCode.Generic => ResultFileName.CodeDistribution,
+        DistributionCode.Demographics => ResultFileName.DemographicsDistribution,
         _ => throw new NotImplementedException(notImplementedMessage)
       },
       _ => throw new NotImplementedException(notImplementedMessage)

--- a/tests/Hutch.Rackit.Tests/ResultFileExtensionsTests/WithAnalysisFileNameTests.cs
+++ b/tests/Hutch.Rackit.Tests/ResultFileExtensionsTests/WithAnalysisFileNameTests.cs
@@ -22,7 +22,7 @@ public class WithAnalysisFileNameTests
     var resultFile = new ResultFile();
 
     Assert.Throws<NotImplementedException>(() =>
-      resultFile.WithAnalysisFileName(analysisCode, analysisCode));
+      resultFile.WithAnalysisFileName(analysisType, analysisCode));
   }
 
   [Theory]

--- a/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/GenericDistributionAggregatorTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/GenericDistributionAggregatorTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Hutch.Rackit.TaskApi;
+using Hutch.Rackit.TaskApi.Models;
+using Hutch.Relay.Constants;
+using Hutch.Relay.Models;
+using Hutch.Relay.Services;
+using Hutch.Relay.Services.JobResultAggregators;
+using Microsoft.VisualBasic;
+using Moq;
+using Xunit;
+
+namespace Hutch.Relay.Tests.Services.QueryResultAggregators;
+
+public class GenericDistributionAggregatorTests
+{
+  // We don't do in depth obfuscation tests here; they are done in the Obfuscator test suite.
+  // But we do attempt to ensure that the Obfuscator is being applied to aggregate outputs
+
+  #region Test Data
+
+  private static RelaySubTaskModel GenerateSubTaskWithResultsData(List<GenericDistributionRecord> data)
+  {
+    var subTaskId = Guid.NewGuid();
+    var subNodeId = data.FirstOrDefault()?.Collection ?? Guid.NewGuid().ToString();
+
+    return new()
+    {
+      Id = subTaskId,
+      Owner = new() { Id = Guid.NewGuid(), Owner = "test_user" },
+      RelayTask = new()
+      {
+        Id = Guid.NewGuid().ToString(),
+        Collection = "parent_collection",
+        Type = TaskTypes.TaskApi_CodeDistribution,
+      },
+      Result = JsonSerializer.Serialize(new JobResult
+      {
+        Uuid = subTaskId.ToString(),
+        CollectionId = subNodeId,
+        Results = new()
+        {
+          Count = data.Count,
+          DatasetCount = 1,
+          Files =
+          [
+            new ResultFile()
+              .WithAnalysisFileName(AnalysisType.Distribution, DistributionCode.Generic)
+              .WithData(data)
+          ]
+        }
+      })
+    };
+  }
+
+  private static List<GenericDistributionRecord> GenerateSubTaskResults(
+    string collectionId, int[] counts, int codeOffset = 1)
+    => counts.Select((v, i) => new GenericDistributionRecord
+    {
+      Code = $"CODE{i + codeOffset}",
+      Collection = collectionId,
+      Count = v,
+    }).ToList();
+
+  public static readonly RelaySubTaskModel SubTaskNoData = GenerateSubTaskWithResultsData([]);
+
+  public static readonly RelaySubTaskModel SubTaskZeroCounts =
+    GenerateSubTaskWithResultsData(GenerateSubTaskResults(
+      Guid.NewGuid().ToString(),
+      [0, 0, 0]));
+
+  public static readonly RelaySubTaskModel SubTaskWithCounts1 =
+    GenerateSubTaskWithResultsData(GenerateSubTaskResults(
+      Guid.NewGuid().ToString(),
+      [91, 230, 1342, 17]));
+
+  public static readonly RelaySubTaskModel SubTaskWithCounts2 =
+    GenerateSubTaskWithResultsData(GenerateSubTaskResults(
+      Guid.NewGuid().ToString(),
+      [412, 0, 975, 26],
+      3));
+
+  public static IEnumerable<object[]> GetSubTasks()
+  {
+    yield return [new List<RelaySubTaskModel>(), 0, new List<int>()];
+    yield return [new List<RelaySubTaskModel> { SubTaskNoData }, 0, new List<int>()];
+    yield return [new List<RelaySubTaskModel> { SubTaskZeroCounts }, 3, new List<int> { 0, 0, 0 }];
+    yield return [new List<RelaySubTaskModel> { SubTaskWithCounts1 }, 4, new List<int> { 91, 230, 1342, 17 }];
+    yield return
+    [
+      new List<RelaySubTaskModel> { SubTaskZeroCounts, SubTaskWithCounts1, SubTaskWithCounts2 }, 6,
+      new List<int> { 91, 230, 1754, 17, 975, 26 }
+    ];
+  }
+
+  #endregion
+
+  [Fact]
+  public void WhenNoSubTasks_ReturnEmptyQueryResult()
+  {
+    var subTasks = new List<RelaySubTaskModel>();
+
+    var expected = new QueryResult
+    {
+      Count = 0,
+      Files = [],
+      DatasetCount = 0
+    };
+
+    var obfuscator = new Mock<IObfuscator>();
+
+    var aggregator = new GenericDistributionAggregator(obfuscator.Object);
+
+    var actual = aggregator.Process(subTasks);
+
+    Assert.Equivalent(expected, actual);
+  }
+
+  [Theory]
+  [MemberData(nameof(GetSubTasks))]
+  public void ObfuscatorIsCalledOncePerAggregatedFileRow(List<RelaySubTaskModel> subTasks, int aggregatedRowCount,
+    List<int> expectedAggregates)
+  {
+    var obfuscator = new Mock<IObfuscator>();
+
+    var aggregator = new GenericDistributionAggregator(obfuscator.Object);
+    aggregator.Process(subTasks);
+
+    obfuscator.Verify(x => x.Obfuscate(It.IsAny<int>()), Times.Exactly(aggregatedRowCount));
+  }
+
+  [Theory]
+  [MemberData(nameof(GetSubTasks))]
+  public void ReturnsCorrectPropertiesAndAggregates(List<RelaySubTaskModel> subTasks,
+    int aggregatedRowCount,
+    List<int> expectedAggregates)
+  {
+    var obfuscator = new Mock<IObfuscator>();
+    obfuscator.Setup(x => x.Obfuscate(It.IsAny<int>()))
+      .Returns((int value) => value);
+
+    var aggregator = new GenericDistributionAggregator(obfuscator.Object);
+
+    var actual = aggregator.Process(subTasks);
+
+    // Check the count fields
+    Assert.Equal(aggregatedRowCount, actual.Count);
+    if (aggregatedRowCount + expectedAggregates.Count == 0)
+    {
+      // If zero rows, should be no files
+      Assert.Equal(0, actual.DatasetCount);
+      Assert.Empty(actual.Files);
+      return;
+    }
+
+    // With results there should only be 1 file
+    Assert.Equal(1, actual.DatasetCount);
+    Assert.Single(actual.Files);
+
+    // If we have results, parse the result ourselves for assertion
+    var decodedFileResult = actual.Files.Single().DecodeData();
+    var config = CsvConfiguration.FromAttributes<GenericDistributionRecord>();
+    config.MissingFieldFound = null;
+    using var reader = new StringReader(decodedFileResult);
+    using var csv = new CsvReader(reader, config);
+    var rowsByCode = csv.GetRecords<GenericDistributionRecord>()
+      .ToDictionary(x => x.Code, x => (aggregate: x.Count, collection: x.Collection));
+
+    // Check the row count matches what's expected and what's described
+    Assert.Equal(expectedAggregates.Count, rowsByCode.Count);
+    Assert.Equal(actual.Count, rowsByCode.Count);
+
+    // Check each row's count and collection
+    for (var i = 0; i < expectedAggregates.Count; i++)
+    {
+      var expected = expectedAggregates[i];
+      var code = $"CODE{i + 1}";
+
+      Assert.Equal(expected, rowsByCode[code].aggregate);
+      Assert.Equal(subTasks.First().RelayTask.Collection, rowsByCode[code].collection);
+    }
+  }
+}

--- a/tests/Hutch.Relay.Tests/Services/ResultsServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/ResultsServiceTests.cs
@@ -51,6 +51,7 @@ public class ResultsServiceTests
       Options.Create<ApiClientOptions>(new()),
       null!,
       tasks.Object,
+      aggregator.Object,
       aggregator.Object
     );
 


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

This PR adds an Aggregator implementation for Generic Code Distribution Tasks.

Relay now supports The Generic Code Distribution queries from an upstream Task API 🎉

- These task types will not longer be rejected when received during polling for Collection Analysis Jobs.
- They will be passed correctly to downstream clients e.g. Bunny
- When federating to multiple downstream clients, results will be aggregated correctly
- Aggregated results are obfuscated according to configuration
- Aggregated results are submitted correctly upstream
- Federated SubTask expiry times for Distribution Tasks are longer than Availability Tasks

## Related Issues or other material
Closes #47 

## Screenshots, example outputs/behaviour etc.

![Collection Code Distribution data showing in the RQuest GUI after processing a query with Relay + 2 Bunnies](https://github.com/user-attachments/assets/513d4ccf-3bb9-4336-ad06-2163d98288cc)
_Collection Code Distribution data showing in the RQuest GUI after processing a query with Relay + 2 Bunnies]_

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

## [optional] What gif best describes this PR or how it makes you feel?
![A programmer finishing up on his laptop, then turning to the camera and raising his arms in success](https://media1.tenor.com/m/vBJ88Lndi-EAAAAd/and-its-done-its-done.gif)
