### PR TITLE
1.0.0-beta.1 version bump

### DIFF
--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>1.0.0-alpha.4</Version>
+    <Version>1.0.0-beta.1</Version>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🛠️ Repo maintenance

## PR Description

This PR bumps the Relay source version to `1.0.0-beta.1` as we mark completion of the required code issues in the `1.0.0` milestone.

Relay development should switch to documentation, stability testing, and bug fixes, potentially with minor feature additions if they are complete in time, but no further feature development should prevent reaching `1.0.0`.
