### PR TITLE
Scoped Entity Framework DB Contexts for parallel task handling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet-postgres
+{
+    "name": "C# (.NET) and PostgreSQL",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "nromanov.dotrush",
+                "EditorConfig.EditorConfig"
+            ]
+        }
+    }
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001, 5432],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "dotnet --info",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
         "vscode": {
             "extensions": [
                 "nromanov.dotrush",
-                "EditorConfig.EditorConfig"
+                "EditorConfig.EditorConfig",
+                "ms-azuretools.vscode-docker"
             ]
         }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
             "extensions": [
                 "nromanov.dotrush",
                 "EditorConfig.EditorConfig",
-                "ms-azuretools.vscode-docker"
+                "ms-azuretools.vscode-docker",
+                "adrianwilczynski.user-secrets"
             ]
         }
     }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+    
+    # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    # user: root
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:14.3
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,6 +14,9 @@ services:
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
+
+    environment:
+      Database__ApplyMigrationsOnStartup: true
     
     # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     # user: root
@@ -29,9 +32,19 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
       
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    restart: unless-stopped
+    network_mode: service:db # put us all on the same network so Relay can use localhost
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
+
+    # Use "forwardPorts" in **devcontainer.json** to forward rabbitmq ports (e.g. 5672, 15672) locally. 
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "dotrush.roslyn.projectOrSolutionFiles": [
+    "/workspaces/hutch-relay/Hutch.Relay.sln"
+  ]
+}

--- a/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
+++ b/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
@@ -1,0 +1,23 @@
+using Hutch.Rackit;
+
+namespace Hutch.Relay.Config;
+
+public class TaskApiPollingOptions : ApiClientOptions
+{
+  /// <summary>
+  /// <para>
+  /// Whether to resume polling after a non-critical error occurs, swallowing (but logging) the exception.
+  /// May be desirable in some environments.
+  /// </para>
+  /// <para>
+  /// Container orchestrated (k8s, compose) or systemd service environments should prefer to always terminate,
+  /// and control restarting the application themselves.
+  /// </para>
+  /// </summary>
+  public bool ResumeOnError { get; set; } = false;
+
+  /// <summary>
+  /// The delay in seconds to wait before resuming polling after an error occurs.
+  /// </summary>
+  public int ErrorDelay { get; set; } = 5;
+}

--- a/app/Hutch.Relay/Extensions/ExceptionDataExtensions.cs
+++ b/app/Hutch.Relay/Extensions/ExceptionDataExtensions.cs
@@ -1,0 +1,15 @@
+namespace Hutch.Relay.Extensions;
+
+public static class ExceptionDataExtensions
+{
+  public static LogLevel? LogLevel(this Exception e)
+  {
+    return e.Data.Contains(nameof(LogLevel)) && e.Data[nameof(LogLevel)] is LogLevel logLevel ? logLevel : null;
+  }
+
+  public static T WithLogLevel<T>(this T e, LogLevel logLevel) where T : Exception
+  {
+    e.Data.Add(nameof(LogLevel), Microsoft.Extensions.Logging.LogLevel.Critical);
+    return e;
+  }
+}

--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>1.0.0-beta.1</Version>
+    <Version>1.0.0-beta.2</Version>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -32,5 +32,4 @@
       <_Parameter1>Hutch.Relay.Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
-
 </Project>

--- a/app/Hutch.Relay/Services/Contracts/IRelayTaskService.cs
+++ b/app/Hutch.Relay/Services/Contracts/IRelayTaskService.cs
@@ -32,6 +32,9 @@ public interface IRelayTaskService
       CollectionAnalysisJob { Analysis: AnalysisType.Distribution, Code: DistributionCode.Demographics }
         => TaskTypes.TaskApi_DemographicsDistribution,
 
+      CollectionAnalysisJob { Analysis: AnalysisType.Distribution, Code: DistributionCode.Icd }
+        => throw new ArgumentOutOfRangeException(nameof(task), task, "Unsupported Task API Task Type: ICD-MAIN Distribution"),
+
       _ => throw new ArgumentOutOfRangeException(nameof(task), task, "Unsupported Task API Task Type")
     };
   }

--- a/app/Hutch.Relay/Services/Hosted/BackgroundUpstreamTaskPoller.cs
+++ b/app/Hutch.Relay/Services/Hosted/BackgroundUpstreamTaskPoller.cs
@@ -10,7 +10,16 @@ public class BackgroundUpstreamTaskPoller(
   {
     while (!stoppingToken.IsCancellationRequested)
     {
-      using var scope = serviceScopeFactory.CreateScope(); // TODO: We need more granular scope for EF, e.g. each polling thread? each job handling thread?
+      // use a shortlived scope to run some db checks without keeping a context open
+      using(var initScope = serviceScopeFactory.CreateScope()) {
+        var subnodes = initScope.ServiceProvider.GetRequiredService<SubNodeService>();
+        
+        // Ensure we have subnodes before we start polling; this is considered critical
+        subnodes.EnsureSubNodes();
+      }
+
+      // use a longer-lived scope to run the poller and its threads
+      using var scope = serviceScopeFactory.CreateScope();
       var poller = scope.ServiceProvider.GetRequiredService<UpstreamTaskPoller>();
 
       await poller.PollAllQueues(stoppingToken);

--- a/app/Hutch.Relay/Services/Hosted/BackgroundUpstreamTaskPoller.cs
+++ b/app/Hutch.Relay/Services/Hosted/BackgroundUpstreamTaskPoller.cs
@@ -1,3 +1,5 @@
+using Hutch.Relay.Services.Contracts;
+
 namespace Hutch.Relay.Services.Hosted;
 
 /// <summary>
@@ -11,9 +13,10 @@ public class BackgroundUpstreamTaskPoller(
     while (!stoppingToken.IsCancellationRequested)
     {
       // use a shortlived scope to run some db checks without keeping a context open
-      using(var initScope = serviceScopeFactory.CreateScope()) {
-        var subnodes = initScope.ServiceProvider.GetRequiredService<SubNodeService>();
-        
+      using (var initScope = serviceScopeFactory.CreateScope())
+      {
+        var subnodes = initScope.ServiceProvider.GetRequiredService<ISubNodeService>();
+
         // Ensure we have subnodes before we start polling; this is considered critical
         subnodes.EnsureSubNodes();
       }

--- a/app/Hutch.Relay/Services/SubNodeService.cs
+++ b/app/Hutch.Relay/Services/SubNodeService.cs
@@ -1,5 +1,6 @@
 using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
+using Hutch.Relay.Extensions;
 using Hutch.Relay.Models;
 using Hutch.Relay.Services.Contracts;
 using Microsoft.EntityFrameworkCore;
@@ -12,10 +13,11 @@ public class SubNodeService(ApplicationDbContext db) : ISubNodeService
   {
     var subNodesExist = db.SubNodes.AsNoTracking().Any();
     if (subNodesExist) return;
-    
-    throw new InvalidOperationException("There are no subnodes configured!");
+
+    throw new InvalidOperationException("There are no subnodes configured!")
+      .WithLogLevel(LogLevel.Critical);
   }
-  
+
   /// <summary>
   /// Create a new SubNode associated with the provided user
   /// </summary>

--- a/app/Hutch.Relay/Services/UpstreamTaskPoller.cs
+++ b/app/Hutch.Relay/Services/UpstreamTaskPoller.cs
@@ -124,25 +124,38 @@ public class ScopedTaskHandler(
     if (subnodes.Count == 0) return;
 
     // Create a parent task
-    var relayTask = await relayTasks.Create(new()
+    try
     {
-      Id = job.Uuid,
-      Type = IRelayTaskService.GetTaskApiType(job),
-      Collection = job.Collection
-    });
 
-    // Fan out to subtasks
-    foreach (var subnode in subnodes)
+      var relayTask = await relayTasks.Create(new()
+      {
+        Id = job.Uuid,
+        Type = IRelayTaskService.GetTaskApiType(job),
+        Collection = job.Collection
+      });
+
+      // Fan out to subtasks
+      foreach (var subnode in subnodes)
+      {
+        var subTask = await relayTasks.CreateSubTask(relayTask.Id, subnode.Id);
+
+        // Update the job for the target subnode
+        job.Uuid = subTask.Id.ToString();
+        job.Collection = subnode.Id.ToString();
+        job.Owner = subnode.Owner;
+
+        // Queue the task for the subnode
+        await queues.Send(subnode.Id.ToString(), job);
+      }
+    }
+    catch (ArgumentOutOfRangeException e)
     {
-      var subTask = await relayTasks.CreateSubTask(relayTask.Id, subnode.Id);
-
-      // Update the job for the target subnode
-      job.Uuid = subTask.Id.ToString();
-      job.Collection = subnode.Id.ToString();
-      job.Owner = subnode.Owner;
-
-      // Queue the task for the subnode
-      await queues.Send(subnode.Id.ToString(), job);
+      if (e.Message.Contains("ICD-MAIN"))
+      {
+        logger.LogWarning("Skipping unsupported ICD-MAIN Distribution task: {Id}", job.Uuid);
+        return;
+      }
+      throw;
     }
   }
 }

--- a/app/Hutch.Relay/Services/UpstreamTaskPoller.cs
+++ b/app/Hutch.Relay/Services/UpstreamTaskPoller.cs
@@ -152,7 +152,7 @@ public class ScopedTaskHandler(
     {
       if (e.Message.Contains("ICD-MAIN"))
       {
-        logger.LogWarning("Skipping unsupported ICD-MAIN Distribution task: {Id}", job.Uuid);
+        logger.LogInformation("Skipping unsupported ICD-MAIN Distribution task: {Id}", job.Uuid);
         return;
       }
       throw;

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -66,7 +66,7 @@ public static class ConfigureWebServices
     builder.Services
       .AddHostedService<BackgroundUpstreamTaskPoller>()
       .AddScoped<ScopedTaskHandler>();
-    // builder.Services.AddHostedService<TaskCompletionHostedService>();
+    builder.Services.AddHostedService<TaskCompletionHostedService>();
 
     return builder;
   }

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -34,7 +34,7 @@ public static class ConfigureWebServices
 
     // Upstream Task API
     builder.Services
-      .Configure<ApiClientOptions>(builder.Configuration.GetSection("UpstreamTaskApi"))
+      .Configure<TaskApiPollingOptions>(builder.Configuration.GetSection("UpstreamTaskApi"))
       .AddHttpClient()
       .AddTransient<ITaskApiClient, TaskApiClient>()
       .AddScoped<UpstreamTaskPoller>()

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -35,6 +35,7 @@ public static class ConfigureWebServices
     // Upstream Task API
     builder.Services
       .Configure<TaskApiPollingOptions>(builder.Configuration.GetSection("UpstreamTaskApi"))
+      .Configure<ApiClientOptions>(builder.Configuration.GetSection("UpstreamTaskApi"))
       .AddHttpClient()
       .AddTransient<ITaskApiClient, TaskApiClient>()
       .AddScoped<UpstreamTaskPoller>()

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -63,8 +63,10 @@ public static class ConfigureWebServices
       .AddKeyedTransient<IQueryResultAggregator,DemographicsDistributionAggregator>(nameof(DemographicsDistributionAggregator));
 
     // Hosted Services
-    builder.Services.AddHostedService<BackgroundUpstreamTaskPoller>();
-    builder.Services.AddHostedService<TaskCompletionHostedService>();
+    builder.Services
+      .AddHostedService<BackgroundUpstreamTaskPoller>()
+      .AddScoped<ScopedTaskHandler>();
+    // builder.Services.AddHostedService<TaskCompletionHostedService>();
 
     return builder;
   }

--- a/hutch-relay.c4
+++ b/hutch-relay.c4
@@ -1,0 +1,159 @@
+specification {
+  color person #48aa77
+
+  element actor {
+    notation 'Person, User'
+
+    style {
+      shape person
+    }
+  }
+
+  element system
+  element container
+  element component
+}
+
+model {
+  researcher = actor 'Researcher'
+
+  upstream = system 'Upstream Discovery Service' {
+    style {
+      shape browser
+    }
+  }
+
+  researcher -> upstream
+
+  hutch-relay = system 'Relay' {
+    container relay 'Relay' {
+      style {
+        icon tech:net-core
+      }
+      component rackit 'Task API Client' {
+        technology 'RACKit'
+      }
+      component task-handler 'Task Handler'
+      component aggregator 'Aggregation and Obfuscation'
+      component task-api 'Task API'
+
+      rackit -> upstream 'polls' {
+        technology 'HTTPS'
+      }
+      rackit -> upstream 'submits results' {
+        technology 'HTTPS'
+      }
+
+      rackit -> task-handler 'tasks'
+
+      task-handler -> datastore 'reads/writes state'
+      task-handler -> rabbitmq 'federates tasks'
+
+      task-api -> datastore 'reads/writes state'
+      task-api -> rabbitmq 'fetches tasks'
+
+      aggregator -> datastore 'aggregates results'
+      aggregator -> rackit 'results'
+
+      downstream -> task-api 'polls' {
+        technology 'HTTPS'
+      }
+      downstream -> task-api 'makes API calls' {
+        technology 'HTTPS'
+      }
+      
+    }
+
+    container datastore 'Database' {
+      style {
+        shape storage
+        icon tech:postgresql
+      }
+    }
+
+    container rabbitmq 'RabbitMQ' {
+      style {
+        shape queue
+        icon tech:rabbitmq
+      }
+    }
+  }
+
+  downstream = system 'Downstream Discovery Client' {
+    style {
+      icon https://bunny.health/icons/favicon.ico
+    }
+  }
+}
+
+views {
+
+  /**
+   * @likec4-generated(v1)
+   * iKRoYXNo2Sg1ZGQzMTRhN2Q0ZDhhYjMzY2ZlZTZiOTY5MDE4ODEzNjc1MGIwYmMzqmF1dG9MYXlvdXSBqWRpcmVjdGlvbqJCVKF4NaF5LaV3aWR0aM0C6KZoZWlnaHTNAxKlbm9kZXOEqnJlc2VhcmNoZXKCoWKUNS3NAUDMtKFjwqpkb3duc3RyZWFtgqFilMzRzQKLzQF1zLShY8KraHV0Y2gtcmVsYXmCoWKUzQGIzQFXzQFAzLShY8KodXBzdHJlYW2CoWKUzQHdMM0BQMy0oWPCpWVkZ2Vzg6cxbGZiYXlsgqJjcJGCoXjLQHlDMzMzMzOhectAYQtKYoktZ6FwlJLMq80Cr5LMu80CL5LM2M0BQ5LM6cy+pzFhb252MjeDomNwkYKheMtAgl77qThoI6F5y0BzSAAAAAAAoWyEoXjNAlOhec0BHqV3aWR0aDmmaGVpZ2h0KKFwlJLNAdjNAVeSzQGtzQEoks0BeMztks0BTMy8
+   * pWJkbjU0g6JjcJGCoXjLQHzm3A0ShOehectAgpMzMzMzM6FshKF4zQHToXnNAkqld2lkdGg5pmhlaWdodCihcJSSzQJYzQKvks0CT80CgJLNAkTNAkaSzQI7zQIV
+   */
+  view index {
+    title 'Hutch Relay Context'
+
+    include *
+    autoLayout BottomTop
+
+    style * {
+      color muted
+    }
+
+    style researcher {
+      color person
+    }
+
+    style hutch-relay._ {
+      color primary
+    }
+  }
+
+  /**
+   * @likec4-generated(v1)
+   * iKRoYXNo2SgyMDE2NzI4ZmQ3MGJiMGI2ODgzZjUyYTgyNWI1MWVhZTI3OTRlNWRjqmF1dG9MYXlvdXSBqWRpcmVjdGlvbqJUQqF4B6F50M2ld2lkdGjNA62maGVpZ2h0zQO0pW5vZGVzhqpkb3duc3RyZWFtgqFilBHQzc0Bdcy0oWPCq2h1dGNoLXJlbGF5gqFilAfNASnNAz/NAlihY8OodXBzdHJlYW2CoWKUzQHd0M/NAUDMtKFjwrFodXRjaC1yZWxheS5yZWxheYKhYpTNAd7NAWDNAUDMtKFjwrVodXRjaC1yZWxheS5kYXRhc3RvcmWCoWKUzQHdzQKlzQFAzLShY8K0aHV0Y2gtcmVsYXkucmFiYml0bXGCoWKULs0CWs0BQMysoWPCpWVkZ2VzhKZ1ZHY2Y2yDomNwkYKheMtAd0qfUS7hYqF5y0BofMzMzMzMoWyEoXjNAaWheczxpXdpZHRoOaZoZWlnaHQooXCUks0C
+   * fsy0ks0Cfszlks0Cfs0BI5LNAn7NAVanMWw4OTZtZYOiY3CRgqF4y0CD7La+nx0loXnLQIH8AAAAAAChbISheM0CfKF5zQJdpXdpZHRoGaZoZWlnaHQSoXCUks0CDs0CFJLNAdHNAkWSzQGFzQKBks0BRs0Cs6ZhanU0d3KDomNwkYKheMtAe7ErtRK7UqF5zQIpoWyEoXjNAaShec0CNqV3aWR0aBmmaGVpZ2h0EqFwlJLNAn7NAhSSzQJ+zQJEks0Cfs0CgJLNAn7NArGnMTdiM2w3NoOiY3CRgqF4y0CD7OG9WcJ1oXnLQHHbMzMzMzOhbISheM0CfaF5zPOld2lkdGg5pmhlaWdodCihcJSSzQLuzQIUks0DK80CRZLNA3bNAoCSzQO0zQKy
+   */
+  view of hutch-relay {
+    title 'Hutch Relay Containers'
+
+    include *
+    autoLayout TopBottom
+
+    style * {
+      color muted
+    }
+
+    style hutch-relay._ {
+      color primary
+    }
+  }
+
+  /**
+   * @likec4-generated(v1)
+   * iKRoYXNo2ShmNGRhZTE4MDA4YjE3NDgyOTZjMThkMTBmZGM1ZWEwYTI2YWJkOWE1qmF1dG9MYXlvdXSBqWRpcmVjdGlvbqJUQqF4zKqhedDRpXdpZHRozQbPpmhlaWdodM0FlqVub2Rlc4mqZG93bnN0cmVhbYKhYpTNAr/Q0c0Bdcy0oWPCsWh1dGNoLXJlbGF5LnJlbGF5gqFilM0Cqs0BIM0DRM0C86Fjw6h1cHN0cmVhbYKhYpTNBIvQ1c0BQMy0oWPCtWh1dGNoLXJlbGF5LmRhdGFzdG9yZYKhYpTNAszNBEXNAUDMtKFjwrRodXRjaC1yZWxheS5yYWJiaXRtcYKhYpTM3M0CXc0BQMysoWPCumh1dGNoLXJlbGF5LnJlbGF5LnRhc2stYXBpgqFilM0C0s0BY80BQMy0oWPCvGh1dGNoLXJlbGF5LnJlbGF5LmFnZ3JlZ2F0b3KCoWKUzQSFzQM2zQFAzLShY8K4aHV0Y2gt
+   * cmVsYXkucmVsYXkucmFja2l0gqFilM0Ehs0BV80BQMy0oWPCvmh1dGNoLXJlbGF5LnJlbGF5LnRhc2staGFuZGxlcoKhYpTNA63NAmLNAUDMtKFjwqVlZGdlc4mnMXZ1czlvM4OiY3CRgqF4y0CLtKB6RMawoXnLQGjzMzMzMzOhbISheM0DdKF5zPKld2lkdGg5pmhlaWdodCihcJSSzQN2zLSSzQN2zOWSzQN2zQEjks0Dds0BVqcxeXA2YTBrg6JjcJGCoXjLQJMekPiFdxWhectAgSjMzMzMzaFshKF4zQS6oXnNAjeld2lkdGglpmhlaWdodBKhcJSSzQUkzQNXks0FJM0DhpLNBSTNA8CSzQUkzQPwpm5tNmN6OYOiY3CRgqF4y0CUlYApC6akoXnLQIbiZmZmZmahbISheM0FJqF5zQKhpXdpZHRoLaZoZWlnaHQSoXCUks0FJM0CFJLNBSTNAj6SzQUkzQJvks0FJM0Cmacx
+   * MHpkOG51g6JjcJGCoXjLQJSf3YNQ6XOhectAcZMzMzMzM6FshKF4zQUooXnM8qV3aWR0aDmmaGVpZ2h0KKFwl5LNBITNAzaSzQP+zQNmks0DOs0DsJLNApPNA/qSzQKSzQP7ks0Ckc0D+5LNAo/NA/ynMXh3OXNjd4OiY3CRgqF4y0CPxdaoi+zroXnLQIuHMzMzMzOhbISheM0D3aF5zQOupXdpZHRocqZoZWlnaHQSoXCXks0FXs0ErpLNBXPNBMqSzQWKzQToks0Fo80FAZLNBbfNBRWSzQXNzQUoks0F5M0FOqcxaHIybGZ4g6JjcJGCoXjLQImlmZmZmZqhectAhcQCRbv4VaFshKF4zQLkoXnNArild2lkdGhjpmhlaWdodBKhcJSSzQSEzQSCks0Dq80EvpLNAijNBSmSzQFKzQVnpzEwcnc4b2iDomNwkYKheMtAkZh3yBOmEaF5y0CQFTMzMzMzoWyEoXjNBEmhec0EGKV3
+   * aWR0aHemaGVpZ2h0EqFwmpLNBcTNAc2SzQYbzQHfks0Ggc0CBJLNBr3NAlCSzQd5zQNCks0HGc0D3ZLNBr3NBQGSzQa4zQUSks0GsM0FI5LNBqjNBTOmMmN2a2N3g6JjcJGCoXjLQIt/Qi90IvehectAhfMzMzMzM6FshKF4zQNvoXnNAy6ld2lkdGhypmhlaWdodBKhcJqSzQQWzQIBks0EKM0CCJLNBDvNAg+SzQRNzQIUks0FDc0CUJLNBYvNAfySzQX7zQKjks0Ggs0DbJLNBoHNBJeSzQZ1zQUypzE5OHhma2SDomNwkYKheMtAhNszMzMzM6F5y0CBMUzm6PMmoWyEoXjNAnehec0COKV3aWR0aFamaGVpZ2h0EqFwl5LNAvLNAhSSzQJmzQJ6ks0Bi80DLJLNAQ/NA/qSzNTNBF2SzLfNBOCSzKrNBTc=
+   */
+  view of hutch-relay.relay {
+    title 'Relay Components'
+    include *
+    autoLayout TopBottom
+
+    style * {
+      color muted
+    }
+
+    style hutch-relay._ {
+      color secondary
+    }
+
+    style relay._ {
+      color primary
+    }
+  }
+}


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
♻️ Refactor
🦋 Bug Fix
⚡️ Optimization

## PR Description

This PR bumps source to beta.2 (pending release when appropriate)

It contains the following changes:

### Scoping DB Contexts

This PR reworks (background) polling of the Upstream Task API so that:
- The main polling thread only uses it's (long-lived) DB Context for untracked reads
- Each job retrieved by polling is handled on its own thread with its own scope
    - Therefore each job gets its own scoped DB Context while being handled

This should prevent entity tracking getting in its own way per #29, and generally be better thread-safe and efficient in general.

Although the root cause of #29 (duplicate task IDs from upstream RQuest) has been resolved upstream, #56 will ultimately resolve the issue of duplicate task IDs in the datastore by, not storing state beyond task resolution.

### Additional changes

This PR also adds a .NET dev container setup for optional use. No prebuilds as yet as this is still being evaluated as an approach.

This PR also adds a WIP C4 model of Relay's architecture using [LikeC4](https://likec4.dev/).

## Related Issues or other material
Related #56 
Closes #29 

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

This PR refactors the composition of already tested units

## [optional] What gif best describes this PR or how it makes you feel?
![ron swanson banging a bug into submission](https://media1.tenor.com/m/tt7KnU6c2-4AAAAd/bug-fix-bug.gif)
