### PR TITLE
State cleanup

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "9.0.1",
+      "version": "9.0.5",
       "commands": [
         "dotnet-ef"
       ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,26 @@
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "./.devcontainer/postCreateCommand.sh", // create a user/subnode immediately; check logs for password / collection id
-  
+
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
+
+  "secrets": {
+    "UpstreamTaskApi__BaseUrl": {
+      "description": "URL to the Upstream Task API",
+      "documentationUrl": "https://hutch.health/relay/config#upstream-task-api"
+    },
+    "UpstreamTaskApi__Username": {
+      "description": "Username for the Upstream Task API",
+      "documentationUrl": "https://hutch.health/relay/config#upstream-task-api"
+    },
+    "UpstreamTaskApi__Password": {
+      "description": "Password for the Upstream Task API",
+      "documentationUrl": "https://hutch.health/relay/config#upstream-task-api"
+    },
+    "UpstreamTaskApi__CollectionId": {
+      "description": "Collection ID for the Upstream Task API",
+      "documentationUrl": "https://hutch.health/relay/config#upstream-task-api"
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,39 +1,38 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet-postgres
 {
-    "name": "C# (.NET) and PostgreSQL",
-    "dockerComposeFile": "docker-compose.yml",
-    "service": "app",
-    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "nromanov.dotrush",
-                "EditorConfig.EditorConfig",
-                "ms-azuretools.vscode-docker",
-                "adrianwilczynski.user-secrets",
-                "patcx.vscode-nuget-gallery"
-            ]
-        }
+  "name": "C# (.NET) and PostgreSQL",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "nromanov.dotrush",
+        "EditorConfig.EditorConfig",
+        "ms-azuretools.vscode-docker",
+        "adrianwilczynski.user-secrets",
+        "patcx.vscode-nuget-gallery"
+      ]
     }
+  },
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  // Configure tool-specific properties.
+  // "customizations": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    5432 // postgres
+  ],
+  // "portsAttributes": {
+  //		"5001": {
+  //			"protocol": "https"
+  //		}
+  // }
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [5000, 5001, 5432],
-	// "portsAttributes": {
-	//		"5001": {
-	//			"protocol": "https"
-	//		}
-	// }
-
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "dotnet --info",
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh", // create a user/subnode immediately; check logs for password / collection id
+  
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
+      POSTGRES_DB: hutch_omop # create a db ready for omop-lite; Relay will create its own db
       
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -46,6 +47,18 @@ services:
 
     # Use "forwardPorts" in **devcontainer.json** to forward rabbitmq ports (e.g. 5672, 15672) locally. 
     # (Adding the "ports" property to this file will not forward from a Codespace.)
+  
+  # used to bootstrap a small db with synthetic data in case of wanting to use Bunny
+  omop-lite:
+    image: ghcr.io/health-informatics-uon/omop-lite
+    depends_on:
+      - db
+    environment:
+      DB_PASSWORD: postgres
+      DB_NAME: hutch_omop
+      SYNTHETIC: true
+  
+  # TODO: add optional bunny? can we configure it?
 
 volumes:
   postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,8 +15,9 @@ services:
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
 
-    environment:
-      Database__ApplyMigrationsOnStartup: true
+    env_file:
+    - path: dev.env
+      required: false
     
     # Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     # user: root
@@ -32,7 +33,6 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
-      POSTGRES_DB: hutch_omop # create a db ready for omop-lite; Relay will create its own db
       
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -47,18 +47,6 @@ services:
 
     # Use "forwardPorts" in **devcontainer.json** to forward rabbitmq ports (e.g. 5672, 15672) locally. 
     # (Adding the "ports" property to this file will not forward from a Codespace.)
-  
-  # used to bootstrap a small db with synthetic data in case of wanting to use Bunny
-  omop-lite:
-    image: ghcr.io/health-informatics-uon/omop-lite
-    depends_on:
-      - db
-    environment:
-      DB_PASSWORD: postgres
-      DB_NAME: hutch_omop
-      SYNTHETIC: true
-  
-  # TODO: add optional bunny? can we configure it?
 
 volumes:
   postgres-data:

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+# aggressively run migrations
+dotnet run --project app/Hutch.Relay -- database update
+
+# create a user/subnode immediately; check logs for password / collection id
+# This may fail if `test` user already exists, but that's not a problem
+dotnet run --project app/Hutch.Relay -- users add test
+
+# sadly if the user does exist, devs will need to exec in to reset the password if they don't know it
+# since we don't want to reset it aggressively here
+
+# we can log out subnode ids for the user though:
+dotnet run --project app/Hutch.Relay -- users list-subnodes test

--- a/.devcontainer/sample.dev.env
+++ b/.devcontainer/sample.dev.env
@@ -1,0 +1,4 @@
+UpstreamTaskApi__BaseUrl=
+UpstreamTaskApi__Username=
+UpstreamTaskApi__Password=
+UpstreamTaskApi__CollectionId=

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,12 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
+# temp area e.g. for temporary local dev config / compose stacks / inputs / outputs etc.
+tmp
+
 # dotenv files
-.env
+*.env
+!sample.*.env
 
 # User-specific files
 *.rsuser

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
+  "[csharp]": {
+    "editor.defaultFormatter": "nromanov.dotrush"
+  },
   "dotrush.roslyn.projectOrSolutionFiles": [
     "/workspaces/hutch-relay/Hutch.Relay.sln"
-  ]
+  ],
+  "remote.localPortHost": "allInterfaces"
 }

--- a/app/Hutch.Relay/Config/DatabaseOptions.cs
+++ b/app/Hutch.Relay/Config/DatabaseOptions.cs
@@ -1,0 +1,23 @@
+namespace Hutch.Relay.Config;
+
+/// <summary>
+/// <para>
+/// Configuration for how Relay interacts with its local Database.
+/// </para>
+///
+/// <para>
+/// Note that the actual connection string is expected in the conventional <c>ConnectionStrings:Default</c> location.
+/// </para>
+/// </summary>
+public class DatabaseOptions
+{
+  /// <summary>
+  /// Whether Relay should automatically migrate to the latest (per the version of Relay being run) schema on startup if necessary.
+  /// </summary>
+  public bool ApplyMigrationsOnStartup { get; set; }
+
+  /// <summary>
+  /// Retain <see cref="Relay.Data.Entities.RelayTask"/> and <see cref="Relay.Data.Entities.RelaySubTask"/> records after they have been completed.
+  /// </summary>
+  public bool RetainCompletedTaskState { get; set; }
+}

--- a/app/Hutch.Relay/Data/Entities/RelaySubTask.cs
+++ b/app/Hutch.Relay/Data/Entities/RelaySubTask.cs
@@ -6,6 +6,6 @@ public class RelaySubTask
 {
   public Guid Id { get; set; }
   public required SubNode Owner { get; set; }
-  public required RelayTask RelayTask { get; set; }
+  [Required] public required RelayTask RelayTask { get; set; }
   public string? Result { get; set; }
 }

--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0-beta.3</Version>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/app/Hutch.Relay/Migrations/20250604103033_RelaySubTask_ParentRequired.Designer.cs
+++ b/app/Hutch.Relay/Migrations/20250604103033_RelaySubTask_ParentRequired.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hutch.Relay.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hutch.Relay.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250604103033_RelaySubTask_ParentRequired")]
+    partial class RelaySubTask_ParentRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/Hutch.Relay/Migrations/20250604103033_RelaySubTask_ParentRequired.cs
+++ b/app/Hutch.Relay/Migrations/20250604103033_RelaySubTask_ParentRequired.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hutch.Relay.Migrations
+{
+    /// <inheritdoc />
+    public partial class RelaySubTask_ParentRequired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RelaySubTasks_RelayTasks_RelayTaskId",
+                table: "RelaySubTasks");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RelayTaskId",
+                table: "RelaySubTasks",
+                type: "character varying(255)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RelaySubTasks_RelayTasks_RelayTaskId",
+                table: "RelaySubTasks",
+                column: "RelayTaskId",
+                principalTable: "RelayTasks",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RelaySubTasks_RelayTasks_RelayTaskId",
+                table: "RelaySubTasks");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RelayTaskId",
+                table: "RelaySubTasks",
+                type: "character varying(255)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RelaySubTasks_RelayTasks_RelayTaskId",
+                table: "RelaySubTasks",
+                column: "RelayTaskId",
+                principalTable: "RelayTasks",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/app/Hutch.Relay/Services/Contracts/IRelayTaskService.cs
+++ b/app/Hutch.Relay/Services/Contracts/IRelayTaskService.cs
@@ -40,7 +40,7 @@ public interface IRelayTaskService
   }
 
   #endregion
-  
+
   /// <summary>
   /// Get a RelayTask by id
   /// </summary>
@@ -63,6 +63,12 @@ public interface IRelayTaskService
   /// <returns></returns>
   /// <exception cref="KeyNotFoundException">The RelayTask does not exist.</exception>
   Task<RelayTaskModel> SetComplete(string id);
+
+  /// <summary>
+  /// Delete a <see cref="RelayTask"/> and all its <see cref="RelaySubTask"/>s.
+  /// </summary>
+  /// <param name="id">The id of the task to delete.</param>
+  Task Delete(string id);
 
   /// <summary>
   /// List RelayTasks that have not been completed.

--- a/app/Hutch.Relay/Services/RelayTaskService.cs
+++ b/app/Hutch.Relay/Services/RelayTaskService.cs
@@ -61,7 +61,8 @@ public class RelayTaskService(ApplicationDbContext db) : IRelayTaskService
   }
 
   /// <summary>
-  /// Set a RelayTask as complete.
+  /// Set a RelayTask as complete. Should only be used if retaining state, as if not retained,
+  /// the task (and its subtasks) will be deleted (and don't need their completed date setting).
   /// </summary>
   /// <param name="id">The id of the task to complete.</param>
   /// <returns></returns>
@@ -85,6 +86,22 @@ public class RelayTaskService(ApplicationDbContext db) : IRelayTaskService
       CompletedAt = entity.CompletedAt,
       Collection = entity.Collection
     };
+  }
+
+  /// <summary>
+  /// Delete a <see cref="RelayTask"/> and all its <see cref="RelaySubTask"/>s.
+  /// </summary>
+  /// <param name="id">The id of the task to delete.</param>
+  /// <exception cref="KeyNotFoundException">The RelayTask does not exist.</exception>
+  public async Task Delete(string id)
+  {
+    var entity = await db.RelayTasks
+                   .SingleOrDefaultAsync(t => t.Id == id);
+
+    if(entity is null) return;
+
+    db.RelayTasks.Remove(entity); // TODO: this should cascade delete the subtasks?
+    await db.SaveChangesAsync();
   }
 
   /// <summary>

--- a/app/Hutch.Relay/Services/ResultsService.cs
+++ b/app/Hutch.Relay/Services/ResultsService.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Hutch.Rackit;
 using Hutch.Rackit.TaskApi.Contracts;
 using Hutch.Rackit.TaskApi.Models;
+using Hutch.Relay.Config;
 using Hutch.Relay.Constants;
 using Hutch.Relay.Models;
 using Hutch.Relay.Services.Contracts;
@@ -12,7 +13,8 @@ namespace Hutch.Relay.Services;
 
 public class ResultsService(
   ILogger<ResultsService> logger,
-  IOptions<ApiClientOptions> options,
+  IOptions<ApiClientOptions> taskApiOptions,
+  IOptions<DatabaseOptions> databaseOptions,
   ITaskApiClient upstreamTasks,
   IRelayTaskService relayTaskService,
   [FromKeyedServices(nameof(AvailabilityAggregator))]
@@ -23,7 +25,8 @@ public class ResultsService(
   IQueryResultAggregator demographicsDistributionAggregator
 )
 {
-  private readonly ApiClientOptions options = options.Value;
+  private readonly ApiClientOptions _taskApiOptions = taskApiOptions.Value;
+  private readonly DatabaseOptions _databaseOptions = databaseOptions.Value;
 
   /// <summary>
   /// Submit a <see cref="JobResult"/> payload Upstream
@@ -41,7 +44,7 @@ public class ResultsService(
       try
       {
         // Submit results upstream
-        await upstreamTasks.SubmitResultAsync(relayTask.Id, jobResult, options);
+        await upstreamTasks.SubmitResultAsync(relayTask.Id, jobResult, _taskApiOptions);
         logger.LogInformation("Successfully submitted results for {RelayTaskId}", relayTask.Id);
         break;
       }
@@ -100,7 +103,10 @@ public class ResultsService(
     finally
     {
       // We should try and close out the task regardless of whether an exception occurred
-      await relayTaskService.SetComplete(task.Id);
+      if (_databaseOptions.RetainCompletedTaskState)
+        await relayTaskService.SetComplete(task.Id);
+      else
+        await relayTaskService.Delete(task.Id);
     }
   }
 

--- a/app/Hutch.Relay/Services/ResultsService.cs
+++ b/app/Hutch.Relay/Services/ResultsService.cs
@@ -80,10 +80,9 @@ public class ResultsService(
   ///       Submitting the final results Upstream
   ///     </item>
   ///     <item>
-  ///       Marking the <see cref="Data.Entities.RelayTask"/> as complete in the Relay datastore.
+  ///       Deleting or completing the <see cref="Data.Entities.RelayTask"/> in the Relay datastore.
   ///     </item>
   ///   </list>
-  /// 1. 
   /// </summary>
   /// <param name="task"><see cref="RelayTaskModel"/> for the task to Complete.</param>
   public async Task CompleteRelayTask(RelayTaskModel task)

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -27,6 +27,7 @@ public static class ConfigureWebServices
 
     var connectionString = builder.Configuration.GetConnectionString("Default");
     builder.Services.AddDbContext<ApplicationDbContext>(o => { o.UseNpgsql(connectionString); });
+    builder.Services.Configure<DatabaseOptions>(builder.Configuration.GetSection("Database"));
 
     builder.Services.AddIdentityCore<RelayUser>(DefaultIdentityOptions.Configure)
       .AddEntityFrameworkStores<ApplicationDbContext>();
@@ -61,7 +62,7 @@ public static class ConfigureWebServices
 
     // Obfuscation
     builder.Services
-      .Configure<ObfuscationOptions>(builder.Configuration.GetSection(("Obfuscation")))
+      .Configure<ObfuscationOptions>(builder.Configuration.GetSection("Obfuscation"))
       .AddTransient<IObfuscator, Obfuscator>();
 
     // Aggregators

--- a/app/Hutch.Relay/Startup/Web/WebEntrypoint.cs
+++ b/app/Hutch.Relay/Startup/Web/WebEntrypoint.cs
@@ -1,6 +1,8 @@
+using Hutch.Relay.Config;
 using Hutch.Relay.Data;
 using Hutch.Relay.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Hutch.Relay.Startup.Web;
 
@@ -17,7 +19,7 @@ public static class WebEntrypoint
     var app = b.Build();
     
     // Make migrations
-    if (app.Configuration.GetValue<bool>("Database:ApplyMigrationsOnStartup"))
+    if (app.Services.GetRequiredService<IOptions<DatabaseOptions>>().Value.ApplyMigrationsOnStartup)
     {
       using var scope = app.Services.CreateScope();
 

--- a/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/GenericDistributionAggregatorTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/GenericDistributionAggregatorTests.cs
@@ -120,7 +120,7 @@ public class GenericDistributionAggregatorTests
   [Theory]
   [MemberData(nameof(GetSubTasks))]
   public void ObfuscatorIsCalledOncePerAggregatedFileRow(List<RelaySubTaskModel> subTasks, int aggregatedRowCount,
-    List<int> expectedAggregates)
+    List<int> _) // expectedAggregates is not used in this test
   {
     var obfuscator = new Mock<IObfuscator>();
 

--- a/tests/Hutch.Relay.Tests/Services/RelayTaskServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/RelayTaskServiceTests.cs
@@ -21,7 +21,31 @@ public class RelayTaskServiceTests(Fixtures fixtures) : IClassFixture<Fixtures>,
     _dbContext.RelayTasks.RemoveRange(_dbContext.RelayTasks);
     await _dbContext.SaveChangesAsync();
   }
-  
+
+  [Fact]
+  public async Task Delete_WithValidId_DeletesRelayTask()
+  {
+    // Arrange
+    var relayTask = new RelayTask
+    {
+      Id = "valid-id-1",
+      Type = TaskTypes.TaskApi_Availability,
+      Collection = "Sample Collection"
+    };
+
+    _dbContext.RelayTasks.Add(relayTask);
+    await _dbContext.SaveChangesAsync();
+
+    var service = new RelayTaskService(_dbContext);
+
+    // Act
+    await service.Delete("valid-id-1");
+
+    // Assert
+    var result = await _dbContext.RelayTasks.FindAsync("valid-id-1");
+    Assert.Null(result);
+  }
+
   [Fact]
   public async Task Get_WithValidId_ReturnsRelayTaskModel()
   {
@@ -52,11 +76,11 @@ public class RelayTaskServiceTests(Fixtures fixtures) : IClassFixture<Fixtures>,
   {
     // Arrange
     var service = new RelayTaskService(_dbContext);
-  
+
     // Act / Assert
     await Assert.ThrowsAsync<KeyNotFoundException>(() => service.Get("DoesNotExist"));
   }
-  
+
   [Fact]
   public async Task Create_ValidRelayTaskModel_ReturnsCreatedRelayTaskModel()
   {
@@ -85,7 +109,7 @@ public class RelayTaskServiceTests(Fixtures fixtures) : IClassFixture<Fixtures>,
     Assert.Equal(model.Collection, entityInDb.Collection);
     Assert.Equal(model.Type, entityInDb.Type);
   }
-  
+
   [Fact]
   public async Task SetComplete_ValidId_UpdatesCompletedAtAndReturnsRelayTaskModel()
   {
@@ -105,13 +129,13 @@ public class RelayTaskServiceTests(Fixtures fixtures) : IClassFixture<Fixtures>,
     var result = await service.SetComplete("valid-id-2");
 
     // Assert
-    Assert.NotNull(result.CompletedAt); 
-    
+    Assert.NotNull(result.CompletedAt);
+
     var entityInDb = await _dbContext.RelayTasks.FindAsync("valid-id-2");
     Assert.NotNull(entityInDb);
     Assert.NotNull(entityInDb.CompletedAt);
   }
-  
+
   [Fact]
   public async Task ListIncomplete_ReturnsOnlyIncompleteTasks()
   {
@@ -146,8 +170,8 @@ public class RelayTaskServiceTests(Fixtures fixtures) : IClassFixture<Fixtures>,
 
     // Assert
     Assert.NotNull(result);
-    Assert.Equal(2, result.Count()); 
-    
+    Assert.Equal(2, result.Count());
+
     var incompleteTasks = result.ToList();
     Assert.Contains(incompleteTasks, x => x.Id == incompleteTask1.Id);
     Assert.Contains(incompleteTasks, x => x.Id == incompleteTask2.Id);

--- a/tests/Hutch.Relay.Tests/Services/ResultsServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/ResultsServiceTests.cs
@@ -49,6 +49,7 @@ public class ResultsServiceTests
     var resultsService = new ResultsService(
       null!,
       Options.Create<ApiClientOptions>(new()),
+      Options.Create<DatabaseOptions>(new()),
       null!,
       tasks.Object,
       aggregator.Object,


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

This PR makes Relay clean up its own local Task state by default.

When Tasks are completed either by all SubTasks resolving, or by expiry, the Task and SubTask records are removed from the local datastore.

A new configuration flag `Database:RetainCompletedTaskState` is available. While `true`, Task and SubTask records will be retained.

Note that when returned to `false`, previously retained records will continue to be retained, requiring manual cleanup. Newly created Tasks will be cleaned up automatically.

## Related Issues or other material
Related https://github.com/Health-Informatics-UoN/hutch/issues/110
Closes #56 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
