### PR TITLE
Demographics genomics default row

### DIFF
--- a/app/Hutch.Relay/Services/JobResultAggregators/AvailabilityAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/AvailabilityAggregator.cs
@@ -6,7 +6,7 @@ namespace Hutch.Relay.Services.JobResultAggregators;
 
 public class AvailabilityAggregator(IObfuscator obfuscator) : IQueryResultAggregator
 {
-  public QueryResult Process(List<RelaySubTaskModel> subTasks)
+  public QueryResult Process(string _, List<RelaySubTaskModel> subTasks)
   {
     // TODO: Availability Results *CAN* contain Results Files too
     // If (when) Relay will support this, those files will need to be aggregated

--- a/app/Hutch.Relay/Services/JobResultAggregators/DemographicsDistributionAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/DemographicsDistributionAggregator.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Text.Json;
 using Hutch.Rackit.TaskApi;
 using Hutch.Rackit.TaskApi.Models;
@@ -9,6 +10,17 @@ namespace Hutch.Relay.Services.JobResultAggregators;
 
 public class DemographicsDistributionAggregator(IObfuscator obfuscator) : IQueryResultAggregator
 {
+  public static DemographicsDistributionRecord GetBaseGenomicsRecord(string collectionId) => new()
+  {
+    Code = Demographics.Genomics,
+    Description = "Genomics",
+    Collection = collectionId,
+    Count = 0,
+    Alternatives = "^No|0^",
+    Dataset = "person",
+    Category = "Demographics"
+  };
+
   public QueryResult Process(string collectionId, List<RelaySubTaskModel> subTasks)
   {
     DemographicsAccumulator accumulator = new(collectionId);
@@ -16,16 +28,7 @@ public class DemographicsDistributionAggregator(IObfuscator obfuscator) : IQuery
     // Always initialise with an empty GENOMICS row as RQuest UI expects it; Results data can supplement it as necessary
     // TODO: also need to aggregate correctly into the Genomics row under "No" if Genomics are missing?
     accumulator.Alternatives.Add(Demographics.Genomics,
-      new(new()
-      {
-        Code = Demographics.Genomics,
-        Description = "Genomics",
-        Collection = collectionId,
-        Count = 0,
-        Alternatives = "^No|0^",
-        Dataset = "person",
-        Category = "Demographics"
-      })
+      new(GetBaseGenomicsRecord(collectionId))
       {
         Alternatives = {
           ["No"] = [0]
@@ -104,9 +107,20 @@ internal static class DemographicsDistributionAggregatorExtensions
     this DemographicsAccumulator accumulator,
     List<DemographicsDistributionRecord> records)
   {
+    // If a `Genomics` record is not provided
+    // We will fabricate one by taking the largest provided record count
+    // (realistically all record totals should match anyway)
+    // and recording that as "No" genomic data
+    var genomicsFound = false;
+    var largestTotal = 0;
+
     foreach (var record in records)
     {
       if (record.Code == Demographics.Age) continue;
+      if (record.Code == Demographics.Genomics) genomicsFound = true; // We'll use the provided record
+
+      // calculate record total (in case we need it) by summing alternatives
+      var recordTotal = 0;
 
       if (accumulator.Alternatives.TryGetValue(record.Code, out var alternativesAccumulator))
       {
@@ -115,25 +129,52 @@ internal static class DemographicsDistributionAggregatorExtensions
         // Add Alternatives
         var alternatives = record.GetAlternatives();
 
+
         foreach (var (alternative, value) in alternatives)
         {
           if (!alternativesAccumulator.Alternatives.ContainsKey(alternative))
             alternativesAccumulator.Alternatives[alternative] = [];
+
           alternativesAccumulator.Alternatives[alternative].Add(value);
+          recordTotal += value;
         }
       }
       else
       {
         // Create a brand new coded entry, with a base record we can use later to populate final properties
-        accumulator.Alternatives.Add(
-          record.Code,
-          new(record)
-          {
-            Alternatives = record.GetAlternatives()
+        alternativesAccumulator = new(record)
+        {
+          Alternatives = record.GetAlternatives()
               .Select(x => (x.Key, new List<int> { x.Value }))
               .ToDictionary()
-          });
+        };
+
+        accumulator.Alternatives.Add(
+          record.Code, alternativesAccumulator);
+
+        recordTotal = alternativesAccumulator.Alternatives.Values.Sum(x => x.Sum());
       }
+
+      // update largest total in case we need it
+      if (record.Count > recordTotal) recordTotal = record.Count; // use the reported count if it exceeds the alternatives sum?
+      if (recordTotal > largestTotal) largestTotal = recordTotal;
+    }
+
+    if (!genomicsFound)
+    {
+      // Add our calculated count to the GENOMICS "No" count.
+      // (initialising the Genomics record along the way if necessary)
+      const string NO_KEY = "No";
+
+      if (!accumulator.Alternatives.ContainsKey(Demographics.Genomics))
+        accumulator.Alternatives[Demographics.Genomics] = new(DemographicsDistributionAggregator.GetBaseGenomicsRecord(accumulator.CollectionId));
+
+      var alternativesAccumulator = accumulator.Alternatives[Demographics.Genomics];
+
+      if (!alternativesAccumulator.Alternatives.ContainsKey(NO_KEY))
+        alternativesAccumulator.Alternatives[NO_KEY] = [];
+
+      alternativesAccumulator.Alternatives[NO_KEY].Add(largestTotal);
     }
 
     return accumulator;

--- a/app/Hutch.Relay/Services/JobResultAggregators/DemographicsDistributionAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/DemographicsDistributionAggregator.cs
@@ -26,7 +26,6 @@ public class DemographicsDistributionAggregator(IObfuscator obfuscator) : IQuery
     DemographicsAccumulator accumulator = new(collectionId);
 
     // Always initialise with an empty GENOMICS row as RQuest UI expects it; Results data can supplement it as necessary
-    // TODO: also need to aggregate correctly into the Genomics row under "No" if Genomics are missing?
     accumulator.Alternatives.Add(Demographics.Genomics,
       new(GetBaseGenomicsRecord(collectionId))
       {

--- a/app/Hutch.Relay/Services/JobResultAggregators/GenericDistributionAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/GenericDistributionAggregator.cs
@@ -10,11 +10,11 @@ namespace Hutch.Relay.Services.JobResultAggregators;
 
 public class GenericDistributionAggregator(IObfuscator obfuscator) : IQueryResultAggregator
 {
-  public QueryResult Process(List<RelaySubTaskModel> subTasks)
+  public QueryResult Process(string collectionId, List<RelaySubTaskModel> subTasks)
   {
     // Aggregation State
     (string collectionId, Dictionary<string, GenericDistributionRecord> aggregatedRecords) accumulator =
-      (subTasks.FirstOrDefault()?.RelayTask.Collection ?? string.Empty, new());
+      (collectionId, new());
 
     // Aggregate across all valid subtasks
     foreach (var subTask in subTasks)

--- a/app/Hutch.Relay/Services/JobResultAggregators/IQueryResultAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/IQueryResultAggregator.cs
@@ -6,5 +6,5 @@ namespace Hutch.Relay.Services.JobResultAggregators;
 
 public interface IQueryResultAggregator
 {
-  public QueryResult Process(List<RelaySubTaskModel> subTasks);
+  public QueryResult Process(string collectionId, List<RelaySubTaskModel> subTasks);
 }

--- a/app/Hutch.Relay/Services/ResultsService.cs
+++ b/app/Hutch.Relay/Services/ResultsService.cs
@@ -138,7 +138,7 @@ public class ResultsService(
     {
       Uuid = relayTask.Id,
       CollectionId = relayTask.Collection,
-      Results = aggregator.Process(subTasks)
+      Results = aggregator.Process(relayTask.Collection, subTasks)
     };
   }
 

--- a/lib/Hutch.Rackit/TaskApi/Constants.cs
+++ b/lib/Hutch.Rackit/TaskApi/Constants.cs
@@ -31,3 +31,11 @@ public static class ResultResponseStatus
 {
   public const string Conflict = "CONFLICT";
 }
+
+// This is not exhaustive but represents known keys that we sometimes operate on
+public static class Demographics
+{
+  public const string Age = "AGE";
+  public const string Sex = "SEX";
+  public const string Genomics = "GENOMICS";
+}

--- a/lib/Hutch.Rackit/TaskApi/Models/DemographicsDistributionRecord.cs
+++ b/lib/Hutch.Rackit/TaskApi/Models/DemographicsDistributionRecord.cs
@@ -45,14 +45,14 @@ public record DemographicsDistributionRecord : IResultFileRecord
   public int Count { get; set; }
 
   // Optional additional stats
-  [Name("MIN")] [Index(4)] public int? Min { get; set; }
+  [Name("MIN")][Index(4)] public int? Min { get; set; }
 
   [Index(5)] public double? Q1 { get; set; }
-  [Name("MEDIAN")] [Index(6)] public double? Median { get; set; }
-  [Name("MEAN")] [Index(7)] public double? Mean { get; set; }
+  [Name("MEDIAN")][Index(6)] public double? Median { get; set; }
+  [Name("MEAN")][Index(7)] public double? Mean { get; set; }
 
   [Index(8)] public double? Q3 { get; set; }
-  [Name("MAX")] [Index(9)] public double? Max { get; set; }
+  [Name("MAX")][Index(9)] public double? Max { get; set; }
 
   /// <summary>
   /// <para>
@@ -74,7 +74,7 @@ public record DemographicsDistributionRecord : IResultFileRecord
   // TODO: What is really expected here?
   // May refer to the Table the is relative to, if not a standard ontology term
   // e.g. In Demographics Distribution, `SEX` may appear as a Code against the `person` table.
-  [Name("DATASET")] [Index(11)] public string Dataset { get; set; } = string.Empty;
+  [Name("DATASET")][Index(11)] public string Dataset { get; set; } = string.Empty;
 
   /// <summary>
   /// Raw OMOP Code for the term. If <see cref="Code"/> is prefixed `OMOP:` the values should match.
@@ -105,32 +105,60 @@ public static class DemographicsDistributionRecordExtensions
   /// <summary>
   /// A lookup by <see cref="Code"/> that provides the expected keys and their order for the <see cref="Alternatives"/> property.
   /// </summary>
-  private static readonly Dictionary<string, string> AlternativeKeys = new()
+  private static readonly Dictionary<string, string> _alternativeKeys = new()
   {
-    ["SEX"] = "MALE,FEMALE"
+    [Demographics.Sex] = "MALE,FEMALE",
+    [Demographics.Genomics] = "No,*" // `*` Allows unknown keys to be appended
   };
 
   public static DemographicsDistributionRecord WithAlternatives(
     this DemographicsDistributionRecord record,
     Dictionary<string, int> alternatives)
   {
-    if (alternatives.Count == 0 || record.Code == "AGE") // AGE doesn't use alternatives
+    // early return cases if nothing to do
+    if (alternatives.Count == 0 || record.Code == Demographics.Age) // AGE doesn't use alternatives
     {
       record.Alternatives = string.Empty;
+      return record;
     }
-    else if (AlternativeKeys.ContainsKey(record.Code))
+
+    // See if this is a key we know the expected alternatives for
+    string[] knownAlternatives = _alternativeKeys.GetValueOrDefault(record.Code)?.Split(",") ?? [];
+    var allowUnknownAlternatives = knownAlternatives is [];
+
+    if (knownAlternatives.Length > 0)
     {
       // We know the expected keys / order for this Code
-      record.Alternatives = AlternativeKeys[record.Code].Split(",")
+      record.Alternatives = knownAlternatives
         .Aggregate("^", (current, k) =>
-          current + $"{k}|{alternatives.GetValueOrDefault(k)}^");
+          {
+            if (k == "*") // * isn't a real Key, so don't add it, but change the behaviour
+            {
+              allowUnknownAlternatives = true;
+              return current;
+            }
+
+            return current + $"{k}|{alternatives.GetValueOrDefault(k)}^";
+          });
     }
-    else
+
+    // Either the Code is unknown, or a known Code supports unknown alternatives (`*`)
+    if (allowUnknownAlternatives)
     {
-      // We just set the values as they come
+      // We just set the values we don't already have as they come
       record.Alternatives = alternatives
-        .Aggregate("^", (current, item) =>
-          current + $"{item.Key}|{item.Value}^");
+        .Aggregate(
+          string.IsNullOrWhiteSpace(record.Alternatives)
+            ? "^"
+            : record.Alternatives,
+          (current, item) =>
+          {
+            // Skip keys we already got from knownAlternatives
+            if (knownAlternatives.Contains(item.Key))
+              return current;
+
+            return current + $"{item.Key}|{item.Value}^";
+          });
     }
 
     return record;

--- a/lib/Hutch.Rackit/TaskApi/Models/DemographicsDistributionRecord.cs
+++ b/lib/Hutch.Rackit/TaskApi/Models/DemographicsDistributionRecord.cs
@@ -115,10 +115,13 @@ public static class DemographicsDistributionRecordExtensions
     this DemographicsDistributionRecord record,
     Dictionary<string, int> alternatives)
   {
-    // early return cases if nothing to do
+    // Always zero out the base record's alternatives
+    // Correct values will be constructed from the provided `alternatives` dictionary
+    record.Alternatives = string.Empty;
+
+    // early return cases if nothing else to do
     if (alternatives.Count == 0 || record.Code == Demographics.Age) // AGE doesn't use alternatives
     {
-      record.Alternatives = string.Empty;
       return record;
     }
 

--- a/tests/Hutch.Rackit.Tests/DemographicsDistributionRecordExtensionsTests/WithAlternativesTests.cs
+++ b/tests/Hutch.Rackit.Tests/DemographicsDistributionRecordExtensionsTests/WithAlternativesTests.cs
@@ -1,3 +1,4 @@
+using Hutch.Rackit.TaskApi;
 using Hutch.Rackit.TaskApi.Models;
 
 namespace Hutch.Rackit.Tests.DemographicsDistributionRecordExtensionsTests;
@@ -54,6 +55,30 @@ public class WithAlternativesTests
     ];
   }
 
+  public static IEnumerable<object[]> GetData_GenomicsCode_EncodesAlternativesCorrectly()
+  {
+    yield return
+    [
+      new Dictionary<string, int> { ["No"] = 50, ["Imputed whole genome data"] = 75, ["Imputed partial genome data"] = 104 },
+      "^No|50^Imputed whole genome data|75^Imputed partial genome data|104^" // unexpected keys retained
+    ];
+    yield return
+    [
+      new Dictionary<string, int> { ["Imputed whole genome data"] = 75, ["No"] = 50 },
+      "^No|50^Imputed whole genome data|75^" // Order standardised - known keys first
+    ];
+    yield return
+    [
+      new Dictionary<string, int> { ["Imputed whole genome data"] = 75 },
+      "^No|0^Imputed whole genome data|75^" // missing known keys zeroed
+    ];
+    yield return
+    [
+      new Dictionary<string, int>(),
+      string.Empty
+    ];
+  }
+
   #endregion
 
   [Theory]
@@ -78,7 +103,22 @@ public class WithAlternativesTests
   {
     DemographicsDistributionRecord record = new()
     {
-      Code = "SEX",
+      Code = Demographics.Sex,
+      Collection = "test_collection"
+    };
+
+    record.WithAlternatives(alternatives);
+
+    Assert.Equal(expected, record.Alternatives);
+  }
+
+  [Theory]
+  [MemberData(nameof(GetData_GenomicsCode_EncodesAlternativesCorrectly))]
+  public void GenomicsCode_EncodesAlternativesCorrectly(Dictionary<string, int> alternatives, string expected)
+  {
+    DemographicsDistributionRecord record = new()
+    {
+      Code = Demographics.Genomics,
       Collection = "test_collection"
     };
 
@@ -94,7 +134,7 @@ public class WithAlternativesTests
     
     DemographicsDistributionRecord record = new()
     {
-      Code = "AGE",
+      Code = Demographics.Age,
       Collection = "test_collection"
     };
 

--- a/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/AvailabilityAggregatorTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/AvailabilityAggregatorTests.cs
@@ -18,6 +18,7 @@ public class AvailabilityAggregatorTests
   public void WhenNoSubTasks_ReturnEmptyQueryResult()
   {
     var subTasks = new List<RelaySubTaskModel>();
+    var collectionId = "test-collection";
 
     var expected = new QueryResult
     {
@@ -30,7 +31,7 @@ public class AvailabilityAggregatorTests
 
     var aggregator = new AvailabilityAggregator(obfuscator.Object);
 
-    var actual = aggregator.Process(subTasks);
+    var actual = aggregator.Process(collectionId, subTasks);
 
     Assert.Equivalent(expected, actual);
   }
@@ -39,11 +40,12 @@ public class AvailabilityAggregatorTests
   public void ObfuscatorIsCalledOnce()
   {
     var subTasks = new List<RelaySubTaskModel>();
+    var collectionId = "test-collection";
 
     var obfuscator = new Mock<IObfuscator>();
 
     var aggregator = new AvailabilityAggregator(obfuscator.Object);
-    aggregator.Process(subTasks);
+    aggregator.Process(collectionId, subTasks);
 
     obfuscator.Verify(x => x.Obfuscate(It.IsAny<int>()), Times.Once);
   }
@@ -70,6 +72,8 @@ public class AvailabilityAggregatorTests
       }
     };
 
+    var collectionId = subTasks.First().RelayTask.Collection;
+
     var expected = new QueryResult
     {
       Count = expectedCount,
@@ -83,7 +87,7 @@ public class AvailabilityAggregatorTests
 
     var aggregator = new AvailabilityAggregator(obfuscator.Object);
 
-    var actual = aggregator.Process(subTasks);
+    var actual = aggregator.Process(collectionId, subTasks);
 
     Assert.Equivalent(expected, actual);
   }
@@ -114,6 +118,8 @@ public class AvailabilityAggregatorTests
         })
       .ToList();
 
+    var collectionId = subTasks.First().RelayTask.Collection;
+
     var expected = new QueryResult
     {
       Count = expectedCount,
@@ -127,7 +133,7 @@ public class AvailabilityAggregatorTests
 
     var aggregator = new AvailabilityAggregator(obfuscator.Object);
 
-    var actual = aggregator.Process(subTasks);
+    var actual = aggregator.Process(collectionId, subTasks);
 
     Assert.Equivalent(expected, actual);
   }

--- a/tests/Hutch.Relay.Tests/Services/ResultsServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/ResultsServiceTests.cs
@@ -38,12 +38,12 @@ public class ResultsServiceTests
         x.ListSubTasks(
           It.Is<string>(y => y == relayTask.Id),
           It.Is<bool>(y => y == true)))
-      .Returns(() => Task.FromResult<IEnumerable<RelaySubTaskModel>>(new List<RelaySubTaskModel>()));
+      .Returns(() => Task.FromResult<IEnumerable<RelaySubTaskModel>>([]));
 
     var aggregator = new Mock<IQueryResultAggregator>();
     aggregator
       .Setup(x =>
-        x.Process(It.IsAny<List<RelaySubTaskModel>>()))
+        x.Process(It.Is<string>(x => x == relayTask.Collection), It.IsAny<List<RelaySubTaskModel>>()))
       .Returns(() => new() { Count = 0 });
 
     var resultsService = new ResultsService(


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

Matching Bunny https://github.com/Health-Informatics-UoN/hutch-bunny/issues/173 Relay will now ensure a Genomics row is present in Demographics Distribution query results, to populate the RQuest UI's Total Count field on the Collection represented by Relay.

## Related Issues or other material
Closes #61 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
