### PR TITLE
Unified queue upstream

### DIFF
--- a/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
+++ b/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
@@ -23,10 +23,10 @@ public class TaskApiPollingOptions : ApiClientOptions
 
   /// <summary>
   /// <para>Specify which Job Type queues Relay should poll against in the Upstream Task API.</para>
-  /// <para>Can be an empty string or a list of comma separated Task API Job Type codes.</para>
+  /// <para>Can be an empty string, a `*`, or a list of comma separated Task API Job Type codes.</para>
   /// <para>An empty string will cause Relay to poll single "unified" queue for jobs of any type, e.g. when connecting to Upstream Relays</para>
   /// <para>A comma separated list will cause Relay to poll separate queues for each supported type listed, in parallel, e.g. when connecting to upstream RQuest</para>
-  /// <para>Defaults to <c>a,b</c> polling all supported types from separate queues (standard RQuest behaviour)</para>
+  /// <para>Defaults to <c>*</c> polling all supported types from separate queues (standard RQuest behaviour)</para>
   /// </summary>
-  public string QueueTypes { get; set; } = "a,b";
+  public string QueueTypes { get; set; } = "*";
 }

--- a/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
+++ b/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
@@ -20,4 +20,13 @@ public class TaskApiPollingOptions : ApiClientOptions
   /// The delay in seconds to wait before resuming polling after an error occurs.
   /// </summary>
   public int ErrorDelay { get; set; } = 5;
+
+  /// <summary>
+  /// <para>Specify which Job Type queues Relay should poll against in the Upstream Task API.</para>
+  /// <para>Can be an empty string or a list of comma separated Task API Job Type codes.</para>
+  /// <para>An empty string will cause Relay to poll single "unified" queue for jobs of any type, e.g. when connecting to Upstream Relays</para>
+  /// <para>A comma separated list will cause Relay to poll separate queues for each supported type listed, in parallel, e.g. when connecting to upstream RQuest</para>
+  /// <para>Defaults to <c>a,b</c> polling all supported types from separate queues (standard RQuest behaviour)</para>
+  /// </summary>
+  public string QueueTypes { get; set; } = "a,b";
 }

--- a/lib/Hutch.Rackit/TaskApi/Contracts/ITaskApiClient.cs
+++ b/lib/Hutch.Rackit/TaskApi/Contracts/ITaskApiClient.cs
@@ -17,6 +17,16 @@ public interface ITaskApiClient
     where T : TaskApiBaseResponse, new();
 
   /// <summary>
+  /// Repeatedly calls <see cref="FetchNextJobAsync"/> and returns jobs when found.
+  /// </summary>
+  /// <param name="options">The options specified to override the defaults</param>
+  /// <param name="cancellationToken">A token used to cancel the polling loop</param>
+  /// <returns>The next job of the requested type, when available.</returns>
+  public IAsyncEnumerable<(Type type, TaskApiBaseResponse job)> PollUnifiedJobQueue(
+    ApiClientOptions? options = null,
+    CancellationToken cancellationToken = default);
+
+  /// <summary>
   /// Calls <see cref="FetchNextJobAsync"/>, optionally with the options specified in the provided object.
   /// 
   /// Any missing options will fall back to the service's default configured options.

--- a/lib/Hutch.Rackit/TaskApi/Contracts/ITaskApiClient.cs
+++ b/lib/Hutch.Rackit/TaskApi/Contracts/ITaskApiClient.cs
@@ -28,6 +28,31 @@ public interface ITaskApiClient
   public Task<T?> FetchNextJobAsync<T>(ApiClientOptions? options = null) where T : TaskApiBaseResponse, new();
 
   /// <summary>
+  /// Calls <see cref="FetchNextJobAsync"/>, optionally with the options specified in the provided object.
+  /// 
+  /// Any missing options will fall back to the service's default configured options.
+  /// </summary>
+  /// <param name="options">The options specified to override the defaults</param>
+  /// <param name="queueType">Optional Task API Queue Type (e.g. "a", "b"). If omitted, will fetch jobs of all types from a "Unified" queue.</param>
+  /// <returns>A model of the requested job type if one was found; <c>null</c> if not.</returns>
+  /// <exception cref="ArgumentException">A required option is missing because it wasn't provided and is not present in the service defaults</exception>
+  public Task<(Type type, TaskApiBaseResponse job)?> FetchNextJobAsync(ApiClientOptions? options = null, string? queueType = null);
+
+  /// <summary>
+  /// Fetch the next query of any type from a given queue type.
+  /// 
+  /// Queue Type can be specified using the RQuest Job Type codes ("a", "b" etc.) or omitted to use a "unified" queue.
+  /// </summary>
+  /// <param name="baseUrl">Base URL of the API instance to connect to.</param>
+  /// <param name="collectionId">Collection ID to fetch query for.</param>
+  /// <param name="username">Username to use when connecting to the API.</param>
+  /// <param name="password">Password to use when connecting to the API.</param>
+  /// <param name="queueType">Optional Task API Queue Type (e.g. "a", "b"). If omitted, will fetch jobs of all types from a "Unified" queue.</param>
+  /// <returns>A model of the requested query type if one was found; <c>null</c> if not.</returns>
+  /// <exception cref="RackitApiClientException">An unknown type was requested, or an otherwise unexpected error occurred while interacting with the API.</exception>
+  public Task<(Type type, TaskApiBaseResponse job)?> FetchNextJobAsync(string baseUrl, string collectionId, string username, string password, string? queueType = null);
+
+  /// <summary>
   /// Fetch the next query, if any, of the requested type.
   /// </summary>
   /// <typeparam name="T">The type of job (and response model to be returned)</typeparam>


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

This PR adds support for "Unified Queues" in upstream Task APIs.

In practice this means a Relay can connect to a Relay upstream of itself, instead of only RQuest.

This allows chaining of Relays e.g. Rquest -> Relay -> Relay -> Bunny.

### Configuring Queue Types

You can now configure Relay what "queue types" it will poll on an upstream Task API.

This is analogous to Bunny's `TASK_API_QUEUE_TYPE` configuration, except that Relay supports polling more than one queue simultaneously in parallel.

Supported options today are:

- `` (empty string) - poll a "Unififed Queue" (e.g. Relay) where a single queue will return any supported job type.
    - Use this when connecting to another Relay upstream today
    - This matches the Bunny configuration for connecting to Relay
- `a` - Only poll an Availability queue. This matches Bunny configuration for handling Availability queries directly from RQuest
- `b` - Only poll a Collection Analysis (i.e. Distribution) queue. This matches Bunny configuration for handling Distribution queries directly from RQuest
- `a,b` - Simultaneously poll separate queues for Availability and Collection Analysis jobs. This matches the previous Relay behaviour and is expected to be the most common - one Relay instance polling all upstream Rquest queues.
- `*` - Simultaneously poll all supported queue types. This is the default and is equivalent to `a,b` today (but might be e.g. `a,b,c,d` in future)

## Related Issues or other material
Closes #40 
