### PR TITLE
Titlecase alternatives

### DIFF
--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/app/Hutch.Relay/Services/JobResultAggregators/DemographicsDistributionAggregator.cs
+++ b/app/Hutch.Relay/Services/JobResultAggregators/DemographicsDistributionAggregator.cs
@@ -87,7 +87,7 @@ public class DemographicsDistributionAggregator(IObfuscator obfuscator) : IQuery
 
 internal record AlternativesAccumulator(DemographicsDistributionRecord BaseRecord)
 {
-  public Dictionary<string, List<int>> Alternatives { get; init; } = [];
+  public Dictionary<string, List<int>> Alternatives { get; init; } = new(StringComparer.InvariantCultureIgnoreCase);
 }
 
 internal record DemographicsAccumulator(string CollectionId)
@@ -145,7 +145,7 @@ internal static class DemographicsDistributionAggregatorExtensions
         {
           Alternatives = record.GetAlternatives()
               .Select(x => (x.Key, new List<int> { x.Value }))
-              .ToDictionary()
+              .ToDictionary(StringComparer.InvariantCultureIgnoreCase)
         };
 
         accumulator.Alternatives.Add(
@@ -190,9 +190,10 @@ internal static class DemographicsDistributionAggregatorExtensions
     foreach (var (code, value) in accumulator.Alternatives)
     {
       // sum and obfuscate our accumulated data, by alternative key
+      // Alternatives keys should be treated case-insensitive!
       var aggregateAlternatives = value.Alternatives.ToDictionary(
         x => x.Key,
-        x => obfuscator.Obfuscate(x.Value.Sum()));
+        x => obfuscator.Obfuscate(x.Value.Sum()), StringComparer.InvariantCultureIgnoreCase);
 
       // sum the total across all obfuscated alternatives
       var aggregateCount = aggregateAlternatives.Values.Sum();

--- a/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/DemographicsDistributionAggregatorTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/QueryResultAggregators/DemographicsDistributionAggregatorTests.cs
@@ -67,7 +67,7 @@ public class DemographicsDistributionAggregatorTests
         Code = Demographics.Sex,
         Description = "Sex",
         Count = 145,
-        Alternatives = "^MALE|70^FEMALE|75^",
+        Alternatives = "^Male|70^Female|75^",
         Dataset = "person",
         Category = "Demographics"
       },
@@ -291,15 +291,15 @@ public class DemographicsDistributionAggregatorTests
     [
       new() { Code = "EXISTING_CODE", Collection = "sub_collection2", Alternatives = "^BRACKET2|155^BRACKET1|135^" },
       new() { Code = "EXISTING_CODE", Collection = "sub_collection2", Alternatives = "^BRACKET1|27^BRACKET2|32^" },
-      new() { Code = Demographics.Sex, Collection = "sub_collection2", Alternatives = "^MALE|155^FEMALE|135^" },
-      new() { Code = Demographics.Sex, Collection = "sub_collection2", Alternatives = "^MALE|42^FEMALE|68^OTHER|7^" }
+      new() { Code = Demographics.Sex, Collection = "sub_collection2", Alternatives = "^Male|155^Female|135^" },
+      new() { Code = Demographics.Sex, Collection = "sub_collection2", Alternatives = "^Male|42^Female|68^Other|7^" }
     ];
 
     // Much of our expected state has to be redefined manually due to mutable reference types
     Dictionary<string, List<int>> expectedExistingAlternatives =
       new() { ["BRACKET1"] = [50, 135, 27], ["BRACKET2"] = [70, 155, 32] };
     Dictionary<string, List<int>> expectedSexAlternatives =
-      new() { ["MALE"] = [155, 42], ["FEMALE"] = [135, 68], ["OTHER"] = [7] };
+      new() { ["Male"] = [155, 42], ["Female"] = [135, 68], ["Other"] = [7] };
 
     var actual = initialAccumulator.AccumulateData(inputRecords);
 
@@ -330,12 +330,12 @@ public class DemographicsDistributionAggregatorTests
     { Collection = "sub_collection", Code = "AGE", Count = 16, Min = 9, Max = 25, Mean = 16.75, Median = 15.5 };
 
     DemographicsDistributionRecord sexRecord = new()
-    { Code = Demographics.Sex, Collection = "sub_collection", Alternatives = "^MALE|155^FEMALE|135^" };
+    { Code = Demographics.Sex, Collection = "sub_collection", Alternatives = "^Male|155^Female|135^" };
 
     List<DemographicsDistributionRecord> inputRecords = ageOnly ? [ageRecord] : [ageRecord, sexRecord];
 
     Dictionary<string, List<int>> expectedSexAlternatives =
-      new() { ["MALE"] = [155], ["FEMALE"] = [135] };
+      new() { ["Male"] = [155], ["Female"] = [135] };
 
     var actual = initialAccumulator.AccumulateData(inputRecords);
 
@@ -542,7 +542,7 @@ public class DemographicsDistributionAggregatorTests
             Description = "Sex",
             Collection = collectionId,
             Count = 1580,
-            Alternatives = "^MALE|790^FEMALE|790^",
+            Alternatives = "^Male|790^Female|790^",
             Dataset = "person",
             Category = "Demographics",
           },


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description

This PR ensures that known Alternatives Keys in Demographics Desitribution Results are always output as Title Case for submission upstream, but that and case can be accepted (and merged) from downstream results.

## Related Issues or other material
Related https://github.com/Health-Informatics-UoN/hutch-bunny/issues/180
Closes #67 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
