### PR TITLE
Disable Upstream Task API ("Headless Relay")

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
         "EditorConfig.EditorConfig",
         "ms-azuretools.vscode-docker",
         "adrianwilczynski.user-secrets",
-        "patcx.vscode-nuget-gallery"
+        "patcx.vscode-nuget-gallery",
+        "esbenp.prettier-vscode"
       ]
     }
   },

--- a/.devcontainer/sample.dev.env
+++ b/.devcontainer/sample.dev.env
@@ -1,3 +1,4 @@
+UpstreamTaskApi__Enable=true
 UpstreamTaskApi__BaseUrl=
 UpstreamTaskApi__Username=
 UpstreamTaskApi__Password=

--- a/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
+++ b/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
@@ -6,6 +6,16 @@ public class TaskApiPollingOptions : ApiClientOptions
 {
   /// <summary>
   /// <para>
+  /// Whether to enable the functionality of polling an Upstream Task API (and submitting results to it)
+  /// </para>
+  /// <para>
+  /// Enabled by default to match v1.0.0 behaviour
+  /// </para>
+  /// </summary>
+  public bool Enable { get; set; } = true;
+
+  /// <summary>
+  /// <para>
   /// Whether to resume polling after a non-critical error occurs, swallowing (but logging) the exception.
   /// May be desirable in some environments.
   /// </para>

--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.1.0-alpha.1</Version>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -78,9 +78,12 @@ public static class ConfigureWebServices
       .AddKeyedTransient<IQueryResultAggregator, DemographicsDistributionAggregator>(nameof(DemographicsDistributionAggregator));
 
     // Hosted Services
-    builder.Services
-      .AddHostedService<BackgroundUpstreamTaskPoller>()
-      .AddScoped<ScopedTaskHandler>();
+    var isUpstreamTaskApiEnabled = builder.Configuration.GetSection("UpstreamTaskApi").GetValue<bool>("Enable");
+    if (isUpstreamTaskApiEnabled)
+      builder.Services
+        .AddHostedService<BackgroundUpstreamTaskPoller>()
+        .AddScoped<ScopedTaskHandler>();
+
     builder.Services.AddHostedService<TaskCompletionHostedService>();
 
     // Monitoring

--- a/app/Hutch.Relay/appsettings.Development.json
+++ b/app/Hutch.Relay/appsettings.Development.json
@@ -12,6 +12,9 @@
     },
     "WriteTo:1": "Debug"
   },
+  "UpstreamTaskApi": {
+    "Enable": false
+  },
   "RelayTaskQueue": {
     "ConnectionString": "amqp://user:password@localhost:5672"
   },


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

This PR bumps source version to `1.1.0-alpha.1` to indicate code in `main` may now be unstable. No `alpha.1` release is expected yet.

This PR adds the ability to disable Relay's Upstream Task API features.

These features are enabled by default, matching Relay v1.0.0.

They are disabled by default in local development, so developers do not need a valid Upstream configuration to debug Relay.

When disabled, by setting `UpstreamTaskApi__Enable` to `false`, the following effects occur:

- All other `UpstreamTaskApi` configuration is not required
- The background polling service which polls the Upstream Task API for jobs will not start.
- When Relay receives results from downstream clients, it will not submit them to an Upstream Task API.

## Related Issues or other material
Closes #27 

## ✅ Added/updated tests?
- [] This PR contains relevant tests / Or doesn't need to per the below explanation

## [optional] What gif best describes this PR or how it makes you feel?
![alt_text](gif_link)
