### PR TITLE
Distribution caching for Filtering Terms

### DIFF
--- a/app/Hutch.Relay/Data/ApplicationDbContext.cs
+++ b/app/Hutch.Relay/Data/ApplicationDbContext.cs
@@ -9,11 +9,17 @@ namespace Hutch.Relay.Data;
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
   : IdentityDbContext<IdentityUser>(options)
 {
+  // Users and nodes
   public DbSet<RelayUser> RelayUsers { get; set; }
   public DbSet<SubNode> SubNodes { get; set; }
+
+  // Transient Task state
   public DbSet<RelayTask> RelayTasks { get; set; }
   public DbSet<RelaySubTask> RelaySubTasks { get; set; }
 
+  // Persistent Beacon state
+  public DbSet<FilteringTerm> FilteringTerms { get; set; }
+  
   protected override void OnModelCreating(ModelBuilder modelBuilder)
   {
     base.OnModelCreating(modelBuilder);

--- a/app/Hutch.Relay/Data/Entities/FilteringTerm.cs
+++ b/app/Hutch.Relay/Data/Entities/FilteringTerm.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Hutch.Relay.Data.Entities;
+
+public class FilteringTerm
+{
+  [Key]
+  public required string Term { get; set; }
+
+  /// <summary>
+  /// Category for the term as specified by the datasource.
+  /// 
+  /// In Task API Generic Code Distribution this will be e.g. `Gender`, `Condition`, etc.
+  /// </summary>
+  public required string SourceCategory { get; set; }
+
+  /// <summary>
+  /// What we mapped the SourceCategory to,
+  /// for Task API Availability Queries' `varcat` field, e.g. `Gender` -> `person`.
+  /// Note that the mapping is defined by RACKit.
+  /// </summary>
+  public string? VarCat { get; set; }
+  
+  /// <summary>
+  /// Optional Term description, e.g. OMOP Description might be provided by Task API
+  /// </summary>
+  public string? Description { get; set; }
+}

--- a/app/Hutch.Relay/Migrations/20250730094058_Filtering Terms Cache.Designer.cs
+++ b/app/Hutch.Relay/Migrations/20250730094058_Filtering Terms Cache.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hutch.Relay.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hutch.Relay.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250730094058_Filtering Terms Cache")]
+    partial class FilteringTermsCache
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/Hutch.Relay/Migrations/20250730094058_Filtering Terms Cache.cs
+++ b/app/Hutch.Relay/Migrations/20250730094058_Filtering Terms Cache.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hutch.Relay.Migrations
+{
+    /// <inheritdoc />
+    public partial class FilteringTermsCache : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FilteringTerms",
+                columns: table => new
+                {
+                    Term = table.Column<string>(type: "text", nullable: false),
+                    SourceCategory = table.Column<string>(type: "text", nullable: false),
+                    VarCat = table.Column<string>(type: "text", nullable: true),
+                    Description = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FilteringTerms", x => x.Term);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FilteringTerms");
+        }
+    }
+}

--- a/app/Hutch.Relay/Models/Beacon/FilteringTerm.cs
+++ b/app/Hutch.Relay/Models/Beacon/FilteringTerm.cs
@@ -1,0 +1,21 @@
+namespace Hutch.Relay.Models.Beacon;
+
+public class FilteringTerm
+{
+
+  /// <summary>
+  /// <para>The type of term.</para>
+  /// <para>In practice we only support `ontologyTerm` here today due to the terms source being downstream Task API Code Distribution</para>
+  /// </summary>
+  public required string Type { get; set; } = "ontologyTerm";
+
+  /// <summary>
+  /// The actual filtering term, e.g. a prefixed OMOP code: `OMOP:8507`
+  /// </summary>
+  public required string Id { get; set; }
+
+  /// <summary>
+  /// Optional friendly description or label, e.g. the full description of an OMOP term
+  /// </summary>
+  public string? Label { get; set; }
+}

--- a/app/Hutch.Relay/Services/Contracts/IFilteringTermsService.cs
+++ b/app/Hutch.Relay/Services/Contracts/IFilteringTermsService.cs
@@ -1,0 +1,9 @@
+using Hutch.Rackit.TaskApi.Models;
+
+namespace Hutch.Relay.Services.Contracts;
+
+public interface IFilteringTermsService
+{
+  Task CacheUpdatedTerms(JobResult finalResult);
+  Task RequestUpdatedTerms();
+}

--- a/app/Hutch.Relay/Services/DeclarativeConfigService.cs
+++ b/app/Hutch.Relay/Services/DeclarativeConfigService.cs
@@ -128,7 +128,7 @@ public class DeclarativeConfigService(
 
           await subnodes.Create(user!, id); // TODO: bulk create instead of using the service method?
         }
-        catch (Exception e) when (e is InvalidOperationException || e is ArgumentException)
+        catch (Exception e) when (e is InvalidOperationException || e is ArgumentException || e is DbUpdateException)
         {
           throw new InvalidOperationException(
             $"The specified SubNode for this user could not be added, probably due to clashing with an existing Subnode Id: {id}", e);

--- a/app/Hutch.Relay/Services/FilteringTermsService.cs
+++ b/app/Hutch.Relay/Services/FilteringTermsService.cs
@@ -2,8 +2,10 @@ using Hutch.Rackit.TaskApi;
 using Hutch.Rackit.TaskApi.Models;
 using Hutch.Relay.Config.Beacon;
 using Hutch.Relay.Constants;
+using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
 using Hutch.Relay.Services.Contracts;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 namespace Hutch.Relay.Services;
@@ -12,7 +14,8 @@ public class FilteringTermsService(
   ILogger<FilteringTermsService> logger,
   IOptions<RelayBeaconOptions> beaconOptions,
   ISubNodeService subNodes,
-  IDownstreamTaskService downstreamTasks)
+  IDownstreamTaskService downstreamTasks,
+  ApplicationDbContext db)
 {
   public async Task RequestUpdatedTerms()
   {
@@ -37,10 +40,47 @@ public class FilteringTermsService(
     await downstreamTasks.Enqueue(task, subnodes);
   }
 
-  // public async Task CacheUpdatedTerms(JobResult finalResult)
-  // {
+  public async Task CacheUpdatedTerms(JobResult finalResult)
+  {
+    // Try and get Generic Code Distribution ResultFile
+    List<GenericDistributionRecord> distributionData = [];
+    foreach (var file in finalResult.Results.Files)
+    {
+      // currently explicitly only process the first code distribution file
+      // TODO: is it possible for more than one to be present and should we combine them?!
+      if (distributionData.Count > 0) continue;
 
-  // }
+      if (file.FileName == ResultFileName.CodeDistribution)
+      {
+        var rawFileData = file.DecodeData();
+
+        // Check we have more than just the header row; CsvHelper won't parse it if there's no actual data
+        // This could happen if the QueryResult.Count was a lie ;) or just if the file was populated weirdly
+        if (rawFileData.Split("\n").Length < 2) continue;
+
+        // If we actually have data, go ahead and parse
+        distributionData = ResultFileHelpers.ParseFileData<GenericDistributionRecord>(rawFileData);
+      }
+    }
+
+    if (distributionData is [])
+    {
+      logger.LogWarning(
+        "A FilteringTerms update was attempted from a downstream result that contains no Code Distribution Results. The update will not proceed.");
+      return;
+    }
+
+    var filteringTerms = Map(distributionData);
+
+    await using var transaction = await db.Database.BeginTransactionAsync();
+
+    await db.FilteringTerms.ExecuteDeleteAsync();
+
+    db.AddRange(filteringTerms);
+    await db.SaveChangesAsync();
+
+    await transaction.CommitAsync();
+  }
 
   internal static List<FilteringTerm> Map(List<GenericDistributionRecord> records)
   {

--- a/app/Hutch.Relay/Services/FilteringTermsService.cs
+++ b/app/Hutch.Relay/Services/FilteringTermsService.cs
@@ -15,7 +15,7 @@ public class FilteringTermsService(
   IOptions<RelayBeaconOptions> beaconOptions,
   ISubNodeService subNodes,
   IDownstreamTaskService downstreamTasks,
-  ApplicationDbContext db)
+  ApplicationDbContext db) : IFilteringTermsService
 {
   public async Task RequestUpdatedTerms()
   {

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -85,7 +85,7 @@ public static class ConfigureWebServices
       .Configure<BaseBeaconOptions>(builder.Configuration.GetSection("Beacon"))
       .Configure<RelayBeaconOptions>(builder.Configuration.GetSection("Beacon"));
     if (isBeaconEnabled)
-      builder.Services.AddTransient<FilteringTermsService>();
+      builder.Services.AddTransient<IFilteringTermsService, FilteringTermsService>();
 
     // Hosted Services
     var isUpstreamTaskApiEnabled = builder.Configuration.GetSection("UpstreamTaskApi").GetValue<bool>("Enable");

--- a/lib/Hutch.Rackit/TaskApi/Constants.cs
+++ b/lib/Hutch.Rackit/TaskApi/Constants.cs
@@ -39,3 +39,28 @@ public static class Demographics
   public const string Sex = "SEX";
   public const string Genomics = "GENOMICS";
 }
+
+// This may not be exhaustive, but represents known code categories and their mappings to the `varcat` field if applicable
+// This may be quite OMOP specific today...
+public static class CodeCategory
+{
+  // Known categories
+
+  // OMOP
+  public const string Condition = "Condition";
+  public const string Observation = "Observation";
+  public const string Measurement = "Measurement";
+  public const string Gender = "Gender";
+  public const string Ethnicity = "Ethnicity";
+  public const string Race = "Race";
+
+
+  // VarCat mapping
+  private const string _personVarCat = "person";
+  public static Dictionary<string, string> VarCatMap { get; } = new()
+  {
+    [Gender] = _personVarCat,
+    [Ethnicity] = _personVarCat,
+    [Race] = _personVarCat
+  };
+}

--- a/tests/Hutch.Relay.Tests/Fixtures.cs
+++ b/tests/Hutch.Relay.Tests/Fixtures.cs
@@ -1,14 +1,24 @@
+using System.Data.Common;
 using Hutch.Relay.Data;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace Hutch.Relay.Tests;
 
 public static class FixtureHelpers
 {
-  public static ApplicationDbContext NewDbContext(string? dbName = null)
+  public static ApplicationDbContext NewDbContext(ref DbConnection? sqliteConnection)
   {
+    // EF Core In-Memory is a) not great and b) not workable for us given features we use
+    // https://learn.microsoft.com/en-us/ef/core/testing/testing-without-the-database?source=recommendations#sqlite-in-memory
+
+    // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
+    // at the end of the test (see Dispose below).
+    sqliteConnection = new SqliteConnection("Filename=:memory:");
+    sqliteConnection.Open();
+
     var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-      .UseInMemoryDatabase(databaseName: dbName ?? "TestDatabase")
+      .UseSqlite(sqliteConnection)
       .EnableDetailedErrors()
       .EnableSensitiveDataLogging()
       .Options;

--- a/tests/Hutch.Relay.Tests/Hutch.Relay.Tests.csproj
+++ b/tests/Hutch.Relay.Tests/Hutch.Relay.Tests.csproj
@@ -15,6 +15,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.2" />

--- a/tests/Hutch.Relay.Tests/Services/DeclarativeConfigServiceTests/ReconcileDownstreamUsersTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/DeclarativeConfigServiceTests/ReconcileDownstreamUsersTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Hutch.Relay.Config;
 using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
@@ -14,6 +15,7 @@ namespace Hutch.Relay.Tests.Services.DeclarativeConfigServiceTests;
 
 public class ReconcileDownstreamUsersTests : IDisposable
 {
+  private readonly DbConnection? _connection = null;
   private readonly ApplicationDbContext _dbContext;
   private readonly UpperInvariantLookupNormalizer _normalizer = new();
 
@@ -23,7 +25,7 @@ public class ReconcileDownstreamUsersTests : IDisposable
   public ReconcileDownstreamUsersTests()
   {
     // Ensure a unique DB per Test
-    _dbContext = FixtureHelpers.NewDbContext($"Test_{Guid.NewGuid()}");
+    _dbContext = FixtureHelpers.NewDbContext(ref _connection);
     _dbContext.Database.EnsureCreated();
 
     // Always add some existing imperative config for these tests
@@ -136,6 +138,7 @@ public class ReconcileDownstreamUsersTests : IDisposable
   public void Dispose()
   {
     _dbContext.Database.EnsureDeleted();
+    _connection?.Dispose();
   }
 
   [Fact] // Empty declarative config preserves imperative config

--- a/tests/Hutch.Relay.Tests/Services/FilteringTermsServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/FilteringTermsServiceTests.cs
@@ -1,7 +1,9 @@
+using System.Data.Common;
 using Hutch.Rackit.TaskApi;
 using Hutch.Rackit.TaskApi.Models;
 using Hutch.Relay.Config.Beacon;
 using Hutch.Relay.Constants;
+using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
 using Hutch.Relay.Models;
 using Hutch.Relay.Services;
@@ -13,12 +15,29 @@ using Xunit;
 
 namespace Hutch.Relay.Tests.Services;
 
-public class FilteringTermsServiceTests
+public class FilteringTermsServiceTests : IDisposable
 {
+  private readonly DbConnection? _connection = null;
+
   private static readonly IOptions<RelayBeaconOptions> DefaultOptions = Options.Create<RelayBeaconOptions>(new()
   {
     Enable = true
   });
+
+  private readonly ApplicationDbContext _dbContext;
+
+  public FilteringTermsServiceTests()
+  {
+    // Ensure a unique DB per Test
+    _dbContext = FixtureHelpers.NewDbContext(ref _connection);
+    _dbContext.Database.EnsureCreated();
+  }
+
+  public void Dispose()
+  {
+    _dbContext.Database.EnsureDeleted();
+    _connection?.Dispose();
+  }
 
   [Theory]
   [InlineData(true)]
@@ -43,7 +62,7 @@ public class FilteringTermsServiceTests
       Options.Create<RelayBeaconOptions>(new()
       {
         Enable = isBeaconEnabled
-      }), subNodes.Object, downstreamTasks.Object);
+      }), subNodes.Object, downstreamTasks.Object, _dbContext);
 
     await filteringTermsService.RequestUpdatedTerms();
 
@@ -52,7 +71,7 @@ public class FilteringTermsServiceTests
         LogLevel.Warning, // Match whichever log level you want here
         0, // EventId
         It.Is<It.IsAnyType>((o, t) => string.Equals(
-          "GA4GH Beacon Functionality is disabled; not requesting FilteringTerms.", o.ToString())), // The type here must match the `logger.Log<T>` type used above
+          "GA4GH Beacon Functionality is disabled; not requesting updated Filtering Terms.", o.ToString())), // The type here must match the `logger.Log<T>` type used above
         null, //It.IsAny<Exception>(), // Whatever exception may have been logged with it, change as needed.
         (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), // The message formatter
       isBeaconEnabled ? Times.Never : Times.Once);
@@ -91,7 +110,7 @@ public class FilteringTermsServiceTests
     var downstreamTasks = new Mock<IDownstreamTaskService>();
     downstreamTasks.Setup(x => x.Enqueue(It.IsAny<AvailabilityJob>(), It.IsAny<List<SubNodeModel>>()));
 
-    var service = new FilteringTermsService(logger, DefaultOptions, subNodes.Object, downstreamTasks.Object);
+    var service = new FilteringTermsService(logger, DefaultOptions, subNodes.Object, downstreamTasks.Object, _dbContext);
 
     // Act
     await service.RequestUpdatedTerms();
@@ -240,5 +259,186 @@ public class FilteringTermsServiceTests
       x => Assert.Equivalent(expected[0], x),
       x => Assert.Equivalent(expected[1], x),
       x => Assert.Equivalent(expected[2], x));
+  }
+
+  [Fact]
+  public async Task CacheUpdatedTerms_WhenNoDistributionResults_LogsWarningAndReturns()
+  {
+    // Arrange
+    var results = new JobResult()
+    {
+      Results = new QueryResult()
+      {
+        Files = [ new ResultFile()
+        {
+          FileName = ResultFileName.DemographicsDistribution,
+        }]
+      }
+    };
+
+    var logger = new Mock<ILogger<FilteringTermsService>>();
+
+    var subNodes = Mock.Of<ISubNodeService>();
+
+    var downstreamTasks = Mock.Of<IDownstreamTaskService>();
+
+    var filteringTermsService = new FilteringTermsService(
+      logger.Object,
+      Options.Create<RelayBeaconOptions>(new()
+      {
+        Enable = true
+      }), subNodes, downstreamTasks, _dbContext);
+
+    // Act
+    await filteringTermsService.CacheUpdatedTerms(results);
+
+    // Assert
+    logger.Verify(
+      x => x.Log<It.IsAnyType>( // Must use logger.Log<It.IsAnyType> to sub-out FormattedLogValues, the internal class
+        LogLevel.Warning, // Match whichever log level you want here
+        0, // EventId
+        It.Is<It.IsAnyType>((o, t) => string.Equals(
+          "A FilteringTerms update was attempted from a downstream result that contains no Code Distribution Results. The update will not proceed.", o.ToString())), // The type here must match the `logger.Log<T>` type used above
+        null, //It.IsAny<Exception>(), // Whatever exception may have been logged with it, change as needed.
+        (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), // The message formatter
+      Times.Once);
+
+    // Nothing was done to the DB
+    Assert.Empty(_dbContext.FilteringTerms);
+  }
+
+  [Fact]
+  public async Task CacheUpdatedTerms_WhenEmptyDistributionResults_LogsWarningAndReturns()
+  {
+    // Arrange
+    var results = new JobResult()
+    {
+      Results = new QueryResult()
+      {
+        Files = [ new ResultFile()
+        {
+          FileName = ResultFileName.CodeDistribution,
+        }.WithData("HEADERS,ONLY,NO,RECORDS")]
+      }
+    };
+
+    var logger = new Mock<ILogger<FilteringTermsService>>();
+
+    var subNodes = Mock.Of<ISubNodeService>();
+
+    var downstreamTasks = Mock.Of<IDownstreamTaskService>();
+
+    var filteringTermsService = new FilteringTermsService(
+      logger.Object,
+      Options.Create<RelayBeaconOptions>(new()
+      {
+        Enable = true
+      }), subNodes, downstreamTasks, _dbContext);
+
+    // Act
+    await filteringTermsService.CacheUpdatedTerms(results);
+
+    // Assert
+    logger.Verify(
+      x => x.Log<It.IsAnyType>( // Must use logger.Log<It.IsAnyType> to sub-out FormattedLogValues, the internal class
+        LogLevel.Warning, // Match whichever log level you want here
+        0, // EventId
+        It.Is<It.IsAnyType>((o, t) => string.Equals(
+          "A FilteringTerms update was attempted from a downstream result that contains no Code Distribution Results. The update will not proceed.", o.ToString())), // The type here must match the `logger.Log<T>` type used above
+        null, //It.IsAny<Exception>(), // Whatever exception may have been logged with it, change as needed.
+        (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), // The message formatter
+      Times.Once);
+
+    // Nothing was done to the DB
+    Assert.Empty(_dbContext.FilteringTerms);
+  }
+
+  [Fact]
+  public async Task CacheUpdatedTerms_WhenDistributionResults_ReplacesData()
+  {
+    // Arrange
+    List<FilteringTerm> oldData = [
+      new() {
+        Term = "OMOP:123",
+        SourceCategory = CodeCategory.Observation
+      },
+      new() {
+        Term = "OMOP:456",
+        SourceCategory = CodeCategory.Measurement
+      }
+    ];
+    _dbContext.AddRange(oldData);
+    await _dbContext.SaveChangesAsync();
+
+
+    var results = new JobResult()
+    {
+      Results = new QueryResult()
+      {
+        Files = [ new ResultFile()
+        {
+          FileName = ResultFileName.CodeDistribution,
+        }
+        .WithData(new List<GenericDistributionRecord>() {
+          new() {
+            Code = "OMOP:987",
+            Collection = "",
+            Category = "Gender",
+            OmopDescription = "Male"
+          },
+          new() {
+            Code = "OMOP:654",
+            Collection = "",
+            Category = "Condition",
+            OmopDescription = "Cancer"
+          },
+          new() {
+            Code = "OMOP:321",
+            Collection = "",
+            Category = "Race",
+            OmopDescription = "Human"
+          }
+        })]
+      }
+    };
+
+    List<FilteringTerm> expected = [
+      new() {
+        Term = "OMOP:987",
+        SourceCategory = "Gender",
+        Description = "Male",
+        VarCat = "person"
+      },
+      new() {
+        Term = "OMOP:654",
+        SourceCategory = "Condition",
+        Description = "Cancer",
+      },
+      new() {
+        Term = "OMOP:321",
+        SourceCategory = "Race",
+        Description = "Human",
+        VarCat = "person"
+      }
+    ];
+
+    var logger = new Mock<ILogger<FilteringTermsService>>();
+
+    var subNodes = Mock.Of<ISubNodeService>();
+
+    var downstreamTasks = Mock.Of<IDownstreamTaskService>();
+
+    var filteringTermsService = new FilteringTermsService(
+      logger.Object,
+      Options.Create<RelayBeaconOptions>(new()
+      {
+        Enable = true
+      }), subNodes, downstreamTasks, _dbContext);
+
+    // Act
+    await filteringTermsService.CacheUpdatedTerms(results);
+
+    // Assert
+    Assert.Equivalent(expected, _dbContext.FilteringTerms);
   }
 }

--- a/tests/Hutch.Relay.Tests/Services/RelaySubTaskServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/RelaySubTaskServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Hutch.Relay.Constants;
 using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
@@ -9,18 +10,20 @@ namespace Hutch.Relay.Tests.Services;
 
 public class RelaySubTaskServiceTests : IDisposable
 {
+  private readonly DbConnection? _connection = null;
   private readonly ApplicationDbContext _dbContext;
 
   public RelaySubTaskServiceTests()
   {
     // Ensure a unique DB per Test
-    _dbContext = FixtureHelpers.NewDbContext($"Test_{Guid.NewGuid()}");
+    _dbContext = FixtureHelpers.NewDbContext(ref _connection);
     _dbContext.Database.EnsureCreated();
   }
 
   public void Dispose()
   {
     _dbContext.Database.EnsureDeleted();
+    _connection?.Dispose();
   }
 
   [Fact]

--- a/tests/Hutch.Relay.Tests/Services/RelayTaskServiceTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/RelayTaskServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Hutch.Relay.Constants;
 using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
@@ -10,18 +11,20 @@ namespace Hutch.Relay.Tests.Services;
 
 public class RelayTaskServiceTests : IDisposable
 {
+  private readonly DbConnection? _connection = null;
   private readonly ApplicationDbContext _dbContext;
 
   public RelayTaskServiceTests()
   {
     // Ensure a unique DB per Test
-    _dbContext = FixtureHelpers.NewDbContext($"Test_{Guid.NewGuid()}");
+    _dbContext = FixtureHelpers.NewDbContext(ref _connection);
     _dbContext.Database.EnsureCreated();
   }
 
   public void Dispose()
   {
     _dbContext.Database.EnsureDeleted();
+    _connection?.Dispose();
   }
 
   [Fact]


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

This PR adds "Filtering Terms" caching for Beacon support, when receiving Task API Generic Code Distribution results from downstream.

Also switched to SQLite for in-memory database testing.

## Related Issues or other material
Related #
Closes #79 


## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation

