### PR TITLE
Request Beacon Filtering Terms on Startup

### DIFF
--- a/app/Hutch.Relay/Config/Beacon/RelayBeaconOptions.cs
+++ b/app/Hutch.Relay/Config/Beacon/RelayBeaconOptions.cs
@@ -11,5 +11,40 @@ public class RelayBeaconOptions : BaseBeaconOptions
   /// If Beacon is enabled, should Relay immediately request
   /// filtering terms from configured subnodes on startup?
   /// </summary>
-  public bool RequestFilteringTermsOnStartup { get; set; } = true;
+  public StartupFilteringTermsBehaviour RequestFilteringTermsOnStartup { get; set; }
+}
+
+/// <summary>
+/// Valid options for <see cref="RelayBeaconOptions.RequestFilteringTermsOnStartup"/> 
+/// </summary>
+public enum StartupFilteringTermsBehaviour
+{
+  /// <summary>
+  /// Default. Do not request Beacon Filtering Terms when Relay starts.
+  /// </summary>
+  Never,
+
+  /// <summary>
+  /// Request Beacon Filtering Terms when Relay starts only if there are none cached.
+  /// If there are already in-progress tasks for Filtering Terms, new ones will not be queued
+  /// </summary>
+  IfEmpty,
+
+  /// <summary>
+  /// Force Request Beacon Filtering Terms when Relay starts only if there are none cached.
+  /// New Filtering Terms tasks will be queued even if there are some in-progress.
+  /// </summary>
+  ForceIfEmpty,
+
+  /// <summary>
+  /// Request Beacon Filtering Terms everytime Relay starts.
+  /// If there are already in-progress tasks for Filtering Terms, new ones will not be queued
+  /// </summary>
+  Always,
+
+  /// <summary>
+  /// Force Request Beacon Filtering Terms everytime Relay starts.
+  /// New Filtering Terms tasks will be queued even if there are some in-progress.
+  /// </summary>
+  ForceAlways
 }

--- a/app/Hutch.Relay/Services/Contracts/IFilteringTermsService.cs
+++ b/app/Hutch.Relay/Services/Contracts/IFilteringTermsService.cs
@@ -5,6 +5,7 @@ namespace Hutch.Relay.Services.Contracts;
 
 public interface IFilteringTermsService
 {
+  Task<bool> Any();
   Task CacheUpdatedTerms(JobResult finalResult);
   Task RequestUpdatedTerms(bool force = false);
 

--- a/app/Hutch.Relay/Services/FilteringTermsService.cs
+++ b/app/Hutch.Relay/Services/FilteringTermsService.cs
@@ -18,11 +18,22 @@ public class FilteringTermsService(
   ApplicationDbContext db,
   IRelayTaskService relayTasks) : IFilteringTermsService
 {
+  public async Task<bool> Any()
+  {
+    if (!beaconOptions.Value.Enable)
+    {
+      logger.LogWarning("GA4GH Beacon Functionality is disabled; reporting Filtering Terms cache as empty.");
+      return false;
+    }
+
+    return await db.FilteringTerms.AsNoTracking().AnyAsync();
+  }
+
   public async Task<List<FilteringTerm>> List(int skip = 0, int limit = 10)
   {
     if (!beaconOptions.Value.Enable)
     {
-      logger.LogWarning("GA4GH Beacon Functionality is disabled; returning empty Filtering Terms list");
+      logger.LogWarning("GA4GH Beacon Functionality is disabled; reporting Filtering Terms cache as empty.");
       return [];
     }
 
@@ -36,7 +47,7 @@ public class FilteringTermsService(
         Id = term.Term,
         Label = term.Description
       })
-      .Skip(skip*limit);
+      .Skip(skip * limit);
 
     // limit 0 means unlimited, otherwise add the limit clause
     if (limit != 0) termsQuery = termsQuery.Take(limit);

--- a/tests/Hutch.Relay.Tests/Services/FilteringTermsServiceTests/AnyTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/FilteringTermsServiceTests/AnyTests.cs
@@ -1,0 +1,134 @@
+using System.Data.Common;
+using Hutch.Relay.Config.Beacon;
+using Hutch.Relay.Data;
+using Hutch.Relay.Services;
+using Hutch.Relay.Services.Contracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Hutch.Relay.Tests.Services.FilteringTermsServiceTests;
+
+public class FilteringTermsAnyTests : IDisposable
+{
+  private readonly DbConnection? _connection = null;
+
+  private static readonly IOptions<RelayBeaconOptions> _defaultOptions = Options.Create<RelayBeaconOptions>(new()
+  {
+    Enable = true
+  });
+
+  private readonly ApplicationDbContext _dbContext;
+
+  public FilteringTermsAnyTests()
+  {
+    // Ensure a unique DB per Test
+    _dbContext = FixtureHelpers.NewDbContext(ref _connection);
+    _dbContext.Database.EnsureCreated();
+  }
+
+  public void Dispose()
+  {
+    _dbContext.Database.EnsureDeleted();
+    _connection?.Dispose();
+  }
+
+  [Theory]
+  [InlineData(true)]
+  [InlineData(false)]
+  public async Task Any_WhenBeaconDisabled_Warns(bool isBeaconEnabled)
+  {
+    var logger = new Mock<ILogger<FilteringTermsService>>();
+
+    RelayBeaconOptions beaconOptions = new() { Enable = isBeaconEnabled };
+
+    var service = new FilteringTermsService(
+      logger.Object,
+      Options.Create(beaconOptions),
+      Mock.Of<ISubNodeService>(),
+      Mock.Of<IDownstreamTaskService>(),
+      _dbContext,
+      Mock.Of<IRelayTaskService>());
+
+    await service.Any();
+
+    logger.Verify(
+      x => x.Log<It.IsAnyType>( // Must use logger.Log<It.IsAnyType> to sub-out FormattedLogValues, the internal class
+        LogLevel.Warning, // Match whichever log level you want here
+        0, // EventId
+        It.Is<It.IsAnyType>((o, t) => string.Equals(
+          "GA4GH Beacon Functionality is disabled; reporting Filtering Terms cache as empty.", o.ToString())), // The type here must match the `logger.Log<T>` type used above
+        null, //It.IsAny<Exception>(), // Whatever exception may have been logged with it, change as needed.
+        (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), // The message formatter
+      isBeaconEnabled ? Times.Never : Times.Once);
+  }
+
+  [Fact]
+  public async Task Any_WhenBeaconDisabled_ReturnsFalse()
+  {
+    RelayBeaconOptions beaconOptions = new() { Enable = false };
+
+    var service = new FilteringTermsService(
+      Mock.Of<ILogger<FilteringTermsService>>(),
+      Options.Create(beaconOptions),
+      Mock.Of<ISubNodeService>(),
+      Mock.Of<IDownstreamTaskService>(),
+      _dbContext,
+      Mock.Of<IRelayTaskService>()
+    );
+
+    var actual = await service.Any();
+
+    Assert.False(actual);
+  }
+
+  [Fact]
+  public async Task List_WhenNoTerms_ReturnsFalse()
+  {
+    var service = new FilteringTermsService(
+      Mock.Of<ILogger<FilteringTermsService>>(),
+      _defaultOptions,
+      Mock.Of<ISubNodeService>(),
+      Mock.Of<IDownstreamTaskService>(),
+      _dbContext,
+      Mock.Of<IRelayTaskService>());
+
+    var actual = await service.Any();
+
+    Assert.False(actual);
+  }
+
+  [Fact]
+  public async Task List_WhenCachedTerms_ReturnsTrue()
+  {
+    List<Data.Entities.FilteringTerm> cachedTerms = [
+      new() {
+        Term = "OMOP:123",
+        SourceCategory = "Condition",
+        Description = "An OMOP Condition",
+      },
+      new() {
+        Term = "OMOP:456",
+        SourceCategory = "Gender",
+        Description = "Male",
+        VarCat = "person"
+      }
+    ];
+
+    _dbContext.AddRange(cachedTerms);
+    await _dbContext.SaveChangesAsync();
+
+    var service = new FilteringTermsService(
+      Mock.Of<ILogger<FilteringTermsService>>(),
+      _defaultOptions,
+      Mock.Of<ISubNodeService>(),
+      Mock.Of<IDownstreamTaskService>(),
+      _dbContext,
+      Mock.Of<IRelayTaskService>());
+
+    var actual = await service.Any();
+
+    Assert.True(actual);
+  }
+}


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

Adds the ability to have Relay populate its Beacon Filtering Terms cache at startup, by queueing downstream tasks for Generic Code Distribution.

This is configurable as follows, by setting the value of `Beacon.RequestFilteringTermsOnStartup`:

- `Never` - do not queue Generic Code Distribution tasks at Startup
- `IfEmpty` - if there are no cached terms at startup, then queue Generic Code Distribution tasks if there aren't any already in progress.
- `ForceIfEmpty` - if there are no cached terms at startup, then queue Generic Code Distribution tasks EVEN IF there ARE some already in progress.
- `Always` - Regardless of the state of the cache, queue Generic Code Distribution tasks if there aren't any already in progress.
- `ForceAlways` - Regardless of the state of the cache, queue Generic Code Distribution tasks EVEN IF there ARE some already in progress.

## Related Issues or other material
Related #
Closes #83 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
