### PR TITLE
Beacon individuals GET endpoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
   // "customizations": {},
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
-    5432 // postgres
+    5432, // postgres
+    15672 // Rabbit GUI
   ],
   // "portsAttributes": {
   //		"5001": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,12 +8,10 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "nromanov.dotrush",
         "EditorConfig.EditorConfig",
         "ms-azuretools.vscode-docker",
-        "adrianwilczynski.user-secrets",
-        "patcx.vscode-nuget-gallery",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "ms-dotnettools.vscodeintellicode-csharp"
       ]
     }
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,3 @@
 {
-  "[csharp]": {
-    "editor.defaultFormatter": "nromanov.dotrush"
-  },
-  "dotrush.roslyn.projectOrSolutionFiles": [
-    "/workspaces/hutch-relay/Hutch.Relay.sln"
-  ],
   "remote.localPortHost": "allInterfaces"
 }

--- a/app/Hutch.Relay/Constants/DefaultJsonOptions.cs
+++ b/app/Hutch.Relay/Constants/DefaultJsonOptions.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Hutch.Relay.Constants;
+
+public static class DefaultJsonOptions
+{
+  public static Action<JsonOptions> Configure = o =>
+  {
+    o.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+  };
+
+  public static JsonSerializerOptions Serializer
+  {
+    get
+    {
+      JsonOptions o = new();
+      Configure(o);
+      return o.JsonSerializerOptions;
+    }
+  }
+}

--- a/app/Hutch.Relay/Controllers/Beacon/IndividualsController.cs
+++ b/app/Hutch.Relay/Controllers/Beacon/IndividualsController.cs
@@ -1,11 +1,8 @@
-using System.CodeDom.Compiler;
-using System.ComponentModel.DataAnnotations;
 using Hutch.Relay.Config;
 using Hutch.Relay.Config.Beacon;
 using Hutch.Relay.Constants;
 using Hutch.Relay.Models.Beacon;
 using Hutch.Relay.Services;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement.Mvc;

--- a/app/Hutch.Relay/Models/Beacon/EntryTypeReponse.cs
+++ b/app/Hutch.Relay/Models/Beacon/EntryTypeReponse.cs
@@ -1,0 +1,28 @@
+namespace Hutch.Relay.Models.Beacon;
+
+public class EntryTypeResponse
+{
+  //NOTE: "Info" is an optional placeholder, so Relay omits it currently:
+  // https://b2ri-documentation.readthedocs.io/en/latest/endpoints/individuals.html#tag/GET-Endpoints/operation/getIndividuals
+  
+  public required Meta Meta { get; set; }
+  
+  public required EntryTypeResponseSummary ResponseSummary { get; set; }
+
+  public List<BeaconHandover>? BeaconHandovers { get; set; }
+}
+
+// TODO: understand what Handovers are for? Will Relay ever use them?
+public class BeaconHandover
+{
+  public HandoverType HandoverType { get; set; } = new();
+
+  public string Url { get; set; } = string.Empty;
+}
+
+public class HandoverType
+{
+  public string Id { get; set; } = string.Empty;
+
+  public string Label { get; set; } = string.Empty;
+}

--- a/app/Hutch.Relay/Models/Beacon/EntryTypeResponseSummary.cs
+++ b/app/Hutch.Relay/Models/Beacon/EntryTypeResponseSummary.cs
@@ -1,6 +1,6 @@
 namespace Hutch.Relay.Models.Beacon;
 
-public record IndividualsResponseSummary
+public record EntryTypeResponseSummary
 {
   public bool Exists { get; init; }
   

--- a/app/Hutch.Relay/Models/Beacon/Meta.cs
+++ b/app/Hutch.Relay/Models/Beacon/Meta.cs
@@ -1,0 +1,16 @@
+using Hutch.Relay.Config.Beacon;
+
+namespace Hutch.Relay.Models.Beacon;
+
+public class Meta
+{
+  public string BeaconId { get; set; } = string.Empty;
+
+  public string ApiVersion { get; set; } = "v2.0";
+  
+  //public List<ReturnedSchema> ReturnedSchemas { get; set; } = new();
+  
+  public string ReturnedGranularity { get; set; } = nameof(Granularity.boolean);
+  
+  //public RequestSummary ReceivedRequestSummary { get; set; } = new();
+}

--- a/app/Hutch.Relay/Properties/launchSettings.json
+++ b/app/Hutch.Relay/Properties/launchSettings.json
@@ -3,6 +3,7 @@
   "profiles": {
     "Hutch.Relay": {
       "commandName": "Project",
+      "applicationUrl": "http://*:5000",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }

--- a/app/Hutch.Relay/Services/IndividualsQueryService.cs
+++ b/app/Hutch.Relay/Services/IndividualsQueryService.cs
@@ -111,7 +111,7 @@ public class IndividualsQueryService(
           Type = "TEXT",
           VariableName = "OMOP",
           Value = term.ExtractAfterSubstring(":"),
-          Category = "NotPerson" // TODO: correctly map varcat; for now Bunny just requires it to be present and not "Person" for general queries
+          Category = "Condition" // TODO: correctly map varcat; for now Bunny requires it to be any valid non-Person value
         }
       ).ToList();
 

--- a/app/Hutch.Relay/Services/IndividualsQueryService.cs
+++ b/app/Hutch.Relay/Services/IndividualsQueryService.cs
@@ -15,9 +15,9 @@ public class IndividualsQueryService(
   IDownstreamTaskService downstreamTasks,
   IBeaconResultsQueue resultsQueue)
 {
-  public IndividualsResponseSummary GetResultsSummary(int count)
+  public EntryTypeResponseSummary GetResultsSummary(int count)
   {
-    IndividualsResponseSummary result = new()
+    EntryTypeResponseSummary result = new()
     {
       Exists = count > 0
     };
@@ -31,7 +31,7 @@ public class IndividualsQueryService(
     };
   }
 
-  public IndividualsResponseSummary GetEmptySummary()
+  public EntryTypeResponseSummary GetEmptySummary()
     => GetResultsSummary(0);
 
   public async Task<string?> EnqueueDownstream(List<string> queryTerms)
@@ -80,7 +80,7 @@ public class IndividualsQueryService(
   /// <param name="queueName">The name of the queue to check for results</param>
   /// <returns>The query results as soon as they are available</returns>
   /// <exception cref="ArgumentException">When queue name is an empty value</exception>
-  public async Task<IndividualsResponseSummary> AwaitResults(string queueName)
+  public async Task<EntryTypeResponseSummary> AwaitResults(string queueName)
   {
     if (string.IsNullOrWhiteSpace(queueName))
       throw new ArgumentException(

--- a/app/Hutch.Relay/Services/IndividualsQueryService.cs
+++ b/app/Hutch.Relay/Services/IndividualsQueryService.cs
@@ -110,7 +110,8 @@ public class IndividualsQueryService(
           Operand = "=",
           Type = "TEXT",
           VariableName = "OMOP",
-          Value = term.ExtractAfterSubstring(":")
+          Value = term.ExtractAfterSubstring(":"),
+          Category = "NotPerson" // TODO: correctly map varcat; for now Bunny just requires it to be present and not "Person" for general queries
         }
       ).ToList();
 

--- a/app/Hutch.Relay/Services/RabbitQueues/AsyncSingleMessageConsumer.cs
+++ b/app/Hutch.Relay/Services/RabbitQueues/AsyncSingleMessageConsumer.cs
@@ -1,0 +1,48 @@
+using System.Threading.Channels;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Hutch.Relay.Services.RabbitQueues;
+
+public class AsyncSingleMessageConsumer(IChannel channel) : AsyncDefaultBasicConsumer(channel)
+{
+  private readonly Channel<BasicDeliverEventArgs> _channel =
+    System.Threading.Channels.Channel
+      .CreateBounded<BasicDeliverEventArgs>(1);
+
+  public async Task<BasicDeliverEventArgs> MessageDelivered(CancellationToken cancellationToken = new())
+  {
+    BasicDeliverEventArgs? result = null;
+
+    // No need to loop as you might normally - we handle a single message only
+    var ready = await _channel.Reader.WaitToReadAsync(cancellationToken);
+
+    if (ready) _channel.Reader.TryRead(out result);
+
+    return result ?? throw new InvalidOperationException();
+  }
+
+  public override async Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
+    string exchange,
+    string routingKey, IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body,
+    CancellationToken cancellationToken = new())
+  {
+    // Write a message only if we haven't already completed the channel (which we do after one message)
+    if (await _channel.Writer.WaitToWriteAsync(cancellationToken))
+    {
+      await _channel.Writer.WriteAsync(new(
+          consumerTag,
+          deliveryTag,
+          redelivered,
+          exchange,
+          routingKey,
+          properties,
+          body,
+          cancellationToken),
+        cancellationToken);
+
+      // Close the threading channel since this is a single message consumer only
+      _channel.Writer.Complete();
+    }
+  }
+}

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -44,7 +44,7 @@ public static class ConfigureWebServices
 
     b.Services.AddIdentityCore<RelayUser>(DefaultIdentityOptions.Configure)
       .AddEntityFrameworkStores<ApplicationDbContext>();
-    b.Services.AddControllers();
+    b.Services.AddControllers().AddJsonOptions(DefaultJsonOptions.Configure);
     b.Services.AddEndpointsApiExplorer();
     b.Services.AddAuthentication("Basic")
       .AddScheme<BasicAuthSchemeOptions, BasicAuthHandler>("Basic", opts => { opts.Realm = "relay"; });

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -73,7 +73,9 @@ public static class ConfigureWebServices
           Uri = new(queueConnectionString),
         };
       })
-      .AddSingleton<IRabbitConnectionManager, RabbitConnectionManager>()
+      .AddSingleton<RabbitConnectionManager>()
+      .AddSingleton<IRabbitConnectionManager, RabbitConnectionManager>(s =>
+        s.GetRequiredService<RabbitConnectionManager>())
       .AddSingleton<IQueueConnectionManager, RabbitConnectionManager>(s =>
         s.GetRequiredService<RabbitConnectionManager>())
       .AddTransient<IDownstreamTaskQueue, RabbitDownstreamTaskQueue>()
@@ -108,7 +110,8 @@ public static class ConfigureWebServices
     b.Services
       .Configure<BaseBeaconOptions>()
       .Configure<RelayBeaconOptions>()
-      .AddTransient<IFilteringTermsService, FilteringTermsService>();
+      .AddTransient<IFilteringTermsService, FilteringTermsService>()
+      .AddTransient<IndividualsQueryService>();
 
     // Hosted Services
     var isUpstreamTaskApiEnabled = b.Configuration.IsSectionEnabled(Features.UpstreamTaskApi);

--- a/lib/Hutch.Rackit/TaskApi/Models/AvailabilityJob.cs
+++ b/lib/Hutch.Rackit/TaskApi/Models/AvailabilityJob.cs
@@ -39,14 +39,14 @@ public class Rule
 
   [JsonPropertyName("varname")]
   public string VariableName { get; set; } = string.Empty;
-  
+
   /// <summary>
   /// Variable Category; this can be used to direct queries for a given term at a specific table.
   ///
   /// e.g. MALE should be directed specifically at Person
   /// </summary>
   [JsonPropertyName("varcat")]
-  public string? Category { get; set; }
+  public string Category { get; set; } = string.Empty;
 
   /// <summary>
   /// Note that this isn't really an operand on the value

--- a/tests/Hutch.Relay.Tests/Services/IndividualsQueryServiceTests/AwaitResultsTests.cs
+++ b/tests/Hutch.Relay.Tests/Services/IndividualsQueryServiceTests/AwaitResultsTests.cs
@@ -31,7 +31,7 @@ public class AwaitResultsTests
   {
     const string queueName = "test-queue";
     const int count = 123;
-    var expected = new IndividualsResponseSummary()
+    var expected = new EntryTypeResponseSummary()
     {
       Exists = true,
       NumTotalResults = count


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description

This PR adds the initial GA4GH Beacon `/individuals` GET Endpoint implementation.

It's possible to send GET requests to `/individuals` and have them sent to downstream subnodes, and handle the results.

Currently `varcat` is not fully supported, so `Person` table terms will not resolve correctly.

Further efficiencies and spec compliance to follow.

## Related Issues or other material
Related #
Closes #98 

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
