### PR TITLE
Fixed default feature state loading from config

### DIFF
--- a/app/Hutch.Relay/Auth/Basic/BasicAuthHandler.cs
+++ b/app/Hutch.Relay/Auth/Basic/BasicAuthHandler.cs
@@ -102,6 +102,8 @@ internal class BasicAuthHandler : AuthenticationHandler<BasicAuthSchemeOptions>
 
     try
     {
+      var routeCollectionGuid = Guid.Parse(routeCollectionId.ToString() ?? string.Empty);
+
       var (clientId, clientSecret) = ParseBasicAuthHeader(Request.Headers.Authorization!);
 
       var claimsPrincipal = await Authenticate(clientId, clientSecret);
@@ -113,10 +115,10 @@ internal class BasicAuthHandler : AuthenticationHandler<BasicAuthSchemeOptions>
           .Where(subNode =>
             subNode.RelayUsers.Select(user => user.UserName)
               .Contains(clientId))
-          .Select(x => x.Id.ToString())
+          .Select(x => x.Id)
           .ToList();
 
-        if (!clientCollections.Contains(routeCollectionId.ToString() ?? string.Empty))
+        if (!clientCollections.Contains(routeCollectionGuid))
         {
           Logger.LogWarning("collectionId \'{RouteCollectionId}\' is not valid for clientId \'{ClientId}\'.", routeCollectionId, clientId);
           return AuthenticateResult.Fail("Collection ID is not valid for client credentials.");

--- a/app/Hutch.Relay/Config/Beacon/RelayBeaconOptions.cs
+++ b/app/Hutch.Relay/Config/Beacon/RelayBeaconOptions.cs
@@ -1,6 +1,8 @@
+using Hutch.Relay.Config.Helpers;
+
 namespace Hutch.Relay.Config.Beacon;
 
-public class RelayBeaconOptions : BaseBeaconOptions
+public class RelayBeaconOptions : BaseBeaconOptions, IFeatureOptionsModel
 {
   /// <summary>
   /// Enable or disable the Beacon API.

--- a/app/Hutch.Relay/Config/Features.cs
+++ b/app/Hutch.Relay/Config/Features.cs
@@ -3,11 +3,10 @@ namespace Hutch.Relay.Config;
 
 /// <summary>
 /// Contains Feature Management IDs as constants.
-/// 
 /// </summary>
 public static class Features
 {
-  // NOTE: Some Features may relate to Config Sections
+  // NOTE: Some Features may relate to Config Sections (via IFeatureOptionsModel)
   //   this is defined by using these constants as the OptionsModel section names
   public const string UpstreamTaskApi = "UpstreamTaskApi";
   public const string Beacon = "Beacon";

--- a/app/Hutch.Relay/Config/Helpers/ConfigurationExtensions.cs
+++ b/app/Hutch.Relay/Config/Helpers/ConfigurationExtensions.cs
@@ -2,8 +2,6 @@ namespace Hutch.Relay.Config.Helpers;
 
 public static class ConfigurationExtensions
 {
-  public const string EnableKey = "Enable";
-
   /// <summary>
   /// Configure an OptionsModel by implicitly deriving the Config Section from the type `T`
   /// </summary>
@@ -29,6 +27,9 @@ public static class ConfigurationExtensions
     where T : class
     => config.GetSection(OptionsModel<T>.Section);
 
+  public static IConfiguration GetSection(this IConfiguration config, Type optionsModelType)
+    => config.GetSection(OptionsModel.GetSection(optionsModelType));
+
   /// <summary>
   /// Get a Config Section by implicitly deriving the Config Section name from the type `T`
   /// </summary>
@@ -39,23 +40,30 @@ public static class ConfigurationExtensions
     where T : class
     => config.GetRequiredSection(OptionsModel<T>.Section);
 
+  public static IConfiguration GetRequiredSection(this IConfiguration config, Type optionsModelType)
+    => config.GetRequiredSection(OptionsModel.GetSection(optionsModelType));
+
   /// <summary>
-  /// <para>For any passed Config Section names, declares them as Feature Flags (per Microsoft Feature Management).</para>
-  /// <para>Any sections that contain a boolean `Enable` key will also set the Feature's enabled state, otehrwise enabled will be false</para>
+  /// <para>For any passed <see cref="IFeatureOptionsModel" /> types, declares them as Feature Flags (per Microsoft Feature Management).</para>
+  /// <para>The Feature's enabled state will be set based on binding the IFeatureOptionsModel to its Config Section</para>
   /// </summary>
   /// <param name="config"></param>
   /// <param name="sections">A list of Configuration Section names to declare as Feature Flags</param>
   /// <returns></returns>
-  public static ConfigurationManager DeclareSectionFeatures(this ConfigurationManager config, List<string> sections)
+  public static ConfigurationManager DeclareOptionsModelFeatures(this ConfigurationManager config, List<Type> featureOptionsModelTypes)
   {
     var features = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
     // TODO: Support working with actual pre-declared features too, probably by offsetting `i`
-
-    foreach (var (section, i) in sections.Select((v, i) => (v, i)))
+    foreach (var (featureType, i) in featureOptionsModelTypes.Select((v, i) => (v, i)))
     {
+      if (Activator.CreateInstance(featureType) is not IFeatureOptionsModel feature) continue;
+
+      var section = OptionsModel.GetSection(featureType);
+      config.GetSection(section).Bind(feature);
+
       features[$"feature_management:feature_flags:{i}:id"] = section;
-      features[$"feature_management:feature_flags:{i}:enabled"] = config.IsSectionEnabled(section)
+      features[$"feature_management:feature_flags:{i}:enabled"] = feature.Enable
         ? bool.TrueString
         : bool.FalseString;
     }
@@ -66,21 +74,29 @@ public static class ConfigurationExtensions
   }
 
   /// <summary>
-  /// Check if a config section has an `Enable` key set to `true`.
+  /// Check if a <see cref="IFeatureOptionsModel"/> is Enabled. The Config Section name is implicitly derived from the type `T`.
   /// </summary>
+  /// <typeparam name="T">The class to derive the Config Section and bind an Options model from. Uses the classname without the `Options` suffix, or <see cref="ConfigSectionAttribute"/></typeparam>
   /// <param name="config"></param>
-  /// <param name="section"></param>
   /// <returns></returns>
-  public static bool IsSectionEnabled(this ConfigurationManager config, string section)
-    => config.GetSection(section).GetValue<bool>(EnableKey);
+  public static bool IsEnabled<T>(this ConfigurationManager config)
+    where T : class, IFeatureOptionsModel
+    => config.GetSection<T>().Get<T>()?.Enable ?? false;
 
   /// <summary>
-  ///Check if a config section has an `Enable` key set to `true`. The Config Section name is implicitly derived from the type `T`
+  /// Check if a <see cref="IFeatureOptionsModel"/> is Enabled. The Config Section name is implicitly derived from the type `T`.
+  /// Non IFeatureOptionsModel types will return `false`.
   /// </summary>
-  /// <typeparam name="T">The class to derive the Config Section from. Uses the classname without the `Options` suffix, or <see cref="ConfigSectionAttribute"/></typeparam>
+  /// <param name="type">The class to derive the Config Section and bind an Options model from. Uses the classname without the `Options` suffix, or <see cref="ConfigSectionAttribute"/></typeparam>
   /// <param name="config"></param>
   /// <returns></returns>
-  public static bool IsSectionEnabled<T>(this ConfigurationManager config)
-    where T : class
-    => config.GetSection<T>().GetValue<bool>(EnableKey);
+  public static bool IsEnabled(this ConfigurationManager config, Type type)
+  {
+    if (Activator.CreateInstance(type) is not IFeatureOptionsModel feature) return false;
+
+    var section = OptionsModel.GetSection(type);
+    config.GetSection(section).Bind(feature);
+
+    return feature.Enable;
+  }
 }

--- a/app/Hutch.Relay/Config/Helpers/IFeatureOptionsModel.cs
+++ b/app/Hutch.Relay/Config/Helpers/IFeatureOptionsModel.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Hutch.Relay.Config.Helpers;
+
+public interface IFeatureOptionsModel
+{
+  bool Enable { get; set; }
+}

--- a/app/Hutch.Relay/Config/Helpers/OptionsModel.cs
+++ b/app/Hutch.Relay/Config/Helpers/OptionsModel.cs
@@ -29,16 +29,25 @@ public static class OptionsModel<T>
     get
     {
       var derivedType = typeof(T);
-      var typeInfo = derivedType.GetTypeInfo();
 
-      // ConfigSectionAttribute overrides classname convention
-      var attributes = typeInfo.GetCustomAttributes();
-      foreach (var attribute in attributes)
-        if (attribute is ConfigSectionAttribute sectionAttribute)
-          return sectionAttribute.Section;
-
-      // Remove suffix from classname and use that
-      return derivedType.Name.Replace("Options", "");
+      return OptionsModel.GetSection(derivedType);
     }
+  }
+}
+
+public static class OptionsModel
+{
+  public static string GetSection(Type type)
+  {
+    var typeInfo = type.GetTypeInfo();
+
+    // ConfigSectionAttribute overrides classname convention
+    var attributes = typeInfo.GetCustomAttributes();
+    foreach (var attribute in attributes)
+      if (attribute is ConfigSectionAttribute sectionAttribute)
+        return sectionAttribute.Section;
+
+    // Remove suffix from classname and use that
+    return type.Name.Replace("Options", "");
   }
 }

--- a/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
+++ b/app/Hutch.Relay/Config/TaskApiPollingOptions.cs
@@ -4,7 +4,7 @@ using Hutch.Relay.Config.Helpers;
 namespace Hutch.Relay.Config;
 
 [ConfigSection(Features.UpstreamTaskApi)]
-public class TaskApiPollingOptions : ApiClientOptions
+public class TaskApiPollingOptions : ApiClientOptions, IFeatureOptionsModel
 {
   /// <summary>
   /// <para>

--- a/app/Hutch.Relay/Hutch.Relay.csproj
+++ b/app/Hutch.Relay/Hutch.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>1.1.0-alpha.3</Version>
+    <Version>1.1.0-alpha.4</Version>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -26,9 +26,9 @@ public static class ConfigureWebServices
   public static WebApplicationBuilder ConfigureServices(this WebApplicationBuilder b)
   {
     // Feature Management
-    b.Configuration.DeclareSectionFeatures([
-      Features.UpstreamTaskApi,
-      Features.Beacon
+    b.Configuration.DeclareOptionsModelFeatures([
+      typeof(TaskApiPollingOptions),
+      typeof(RelayBeaconOptions)
     ]);
     b.Services.AddFeatureManagement();
 
@@ -114,7 +114,7 @@ public static class ConfigureWebServices
       .AddTransient<IndividualsQueryService>();
 
     // Hosted Services
-    var isUpstreamTaskApiEnabled = b.Configuration.IsSectionEnabled(Features.UpstreamTaskApi);
+    var isUpstreamTaskApiEnabled = b.Configuration.IsFeatureEnabled<TaskApiPollingOptions>();
     if (isUpstreamTaskApiEnabled)
       b.Services
         .AddHostedService<BackgroundUpstreamTaskPoller>()

--- a/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
+++ b/app/Hutch.Relay/Startup/Web/ConfigureWebServices.cs
@@ -114,7 +114,7 @@ public static class ConfigureWebServices
       .AddTransient<IndividualsQueryService>();
 
     // Hosted Services
-    var isUpstreamTaskApiEnabled = b.Configuration.IsFeatureEnabled<TaskApiPollingOptions>();
+    var isUpstreamTaskApiEnabled = b.Configuration.IsEnabled<TaskApiPollingOptions>();
     if (isUpstreamTaskApiEnabled)
       b.Services
         .AddHostedService<BackgroundUpstreamTaskPoller>()

--- a/dev.compose.yml
+++ b/dev.compose.yml
@@ -45,6 +45,8 @@ services:
       - 8081:8081
     environment:
       Database__ApplyMigrationsOnStartup: true
+      DownstreamUsers__test__Password: testPassword
+      DownstreamUsers__test__SubNode: d7ea6f2a-ce2e-41d6-913a-a1ad2b6b88a9
 
       DOTNET_Environment: Development
       ConnectionStrings__Default: Server=db;Port=5432;Database=hutch_relay;User Id=postgres;Password=postgres

--- a/tests/Hutch.Relay.Tests/Auth/BasicAuthHandlerTests.cs
+++ b/tests/Hutch.Relay.Tests/Auth/BasicAuthHandlerTests.cs
@@ -183,7 +183,7 @@ public class BasicAuthHandlerTests
   [Theory]
   [MemberData(nameof(UserCollectionsFixture.GetUserCollections), MemberType = typeof(UserCollectionsFixture))]
   public async Task HandleAuthenticateAsync_ValidUserCollection_ReturnsSuccessResult(
-    string username, string password, string collectionId)
+    string username, string password, Guid collectionId)
   {
     var handler = new BasicAuthHandler(
       _options,

--- a/tests/Hutch.Relay.Tests/Auth/BasicAuthHandlerTests.cs
+++ b/tests/Hutch.Relay.Tests/Auth/BasicAuthHandlerTests.cs
@@ -29,7 +29,7 @@ public class BasicAuthHandlerTests
       .Returns(new BasicAuthSchemeOptions() { Realm = "test" });
     _options = options.Object;
 
-    _userManager = MockHelpers.TestUserManager(new UserStore<RelayUser>(_fixture.Database));
+    _userManager = MockHelpers.TestUserManager(new UserStore<RelayUser>(_fixture.DbContext));
   }
 
   [Fact]
@@ -39,7 +39,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 
@@ -60,7 +60,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 
@@ -82,7 +82,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 
@@ -104,7 +104,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 
@@ -129,7 +129,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 
@@ -157,7 +157,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 
@@ -189,7 +189,7 @@ public class BasicAuthHandlerTests
       _options,
       new NullLoggerFactory(),
       new UrlTestEncoder(),
-      _fixture.Database,
+      _fixture.DbContext,
       _userManager
     );
 

--- a/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
+++ b/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
@@ -2,8 +2,6 @@ using System.Data.Common;
 using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
-using Moq;
 
 namespace Hutch.Relay.Tests.Auth;
 
@@ -12,11 +10,11 @@ public class UserCollectionsFixture : IDisposable
   private readonly DbConnection? _connection = null;
   public readonly ApplicationDbContext DbContext;
 
-  public static Guid SubNode1 = Guid.NewGuid();
-  public static Guid SubNode2 = Guid.NewGuid();
+  public static Guid SubNode1 { get; } = Guid.NewGuid();
+  public static Guid SubNode2 { get; } = Guid.NewGuid();
 
-  public static (string username, string password) User1 = ("user1", "password1");
-  public static (string username, string password) User2 = ("user2", "password2");
+  public static (string username, string password) User1 { get; } = ("user1", "password1");
+  public static (string username, string password) User2 { get; } = ("user2", "password2");
 
   public UserCollectionsFixture()
   {

--- a/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
+++ b/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
@@ -12,6 +12,12 @@ public class UserCollectionsFixture : IDisposable
   private readonly DbConnection? _connection = null;
   public readonly ApplicationDbContext DbContext;
 
+  public static Guid SubNode1 = Guid.NewGuid();
+  public static Guid SubNode2 = Guid.NewGuid();
+
+  public static (string username, string password) User1 = ("user1", "password1");
+  public static (string username, string password) User2 = ("user2", "password2");
+
   public UserCollectionsFixture()
   {
     // Ensure a unique DB per Test (does it, in a fixture?)
@@ -59,12 +65,6 @@ public class UserCollectionsFixture : IDisposable
     DbContext.Database.EnsureDeleted();
     _connection?.Dispose();
   }
-
-  public static Guid SubNode1 = Guid.NewGuid();
-  public static Guid SubNode2 = Guid.NewGuid();
-
-  public static (string username, string password) User1 = ("user1", "password1");
-  public static (string username, string password) User2 = ("user2", "password2");
 
   public static IEnumerable<object[]> GetUserCollections()
   {

--- a/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
+++ b/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Hutch.Relay.Data;
 using Hutch.Relay.Data.Entities;
 using Microsoft.AspNetCore.Identity;
@@ -6,38 +7,16 @@ using Moq;
 
 namespace Hutch.Relay.Tests.Auth;
 
-public class UserCollectionsFixture
+public class UserCollectionsFixture : IDisposable
 {
-  public readonly ApplicationDbContext Database;
-
-  public static Guid SubNode1 = Guid.NewGuid();
-  public static Guid SubNode2 = Guid.NewGuid();
-
-  public static (string username, string password) User1 = ("user1", "password1");
-  public static (string username, string password) User2 = ("user2", "password2");
-
-  public static IEnumerable<object[]> GetUserCollections()
-  {
-    yield return
-    [
-      User1.username, User1.password,
-      SubNode1
-    ];
-    yield return
-    [
-      User2.username, User2.password,
-      SubNode2
-    ];
-  }
+  private readonly DbConnection? _connection = null;
+  public readonly ApplicationDbContext DbContext;
 
   public UserCollectionsFixture()
   {
-    // Set up a DB Context
-    var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-      .UseInMemoryDatabase(databaseName: "UserCollectionsTestDatabase")
-      .Options;
-
-    Database = new(options);
+    // Ensure a unique DB per Test (does it, in a fixture?)
+    DbContext = FixtureHelpers.NewDbContext(ref _connection);
+    DbContext.Database.EnsureCreated();
 
     // Populate with some test data we can use for authorisation testing
     var hasher = new PasswordHasher<RelayUser>();
@@ -60,9 +39,7 @@ public class UserCollectionsFixture
     users[0].PasswordHash = hasher.HashPassword(users[0], User1.password);
     users[1].PasswordHash = hasher.HashPassword(users[1], User2.password);
 
-    // Database.RelayUsers.AddRange(users);
-
-    Database.SubNodes.AddRange(
+    DbContext.SubNodes.AddRange(
       new()
       {
         Id = SubNode1,
@@ -74,6 +51,32 @@ public class UserCollectionsFixture
         RelayUsers = [users[1]]
       });
 
-    Database.SaveChanges();
+    DbContext.SaveChanges();
+  }
+
+  public void Dispose()
+  {
+    DbContext.Database.EnsureDeleted();
+    _connection?.Dispose();
+  }
+
+  public static Guid SubNode1 = Guid.NewGuid();
+  public static Guid SubNode2 = Guid.NewGuid();
+
+  public static (string username, string password) User1 = ("user1", "password1");
+  public static (string username, string password) User2 = ("user2", "password2");
+
+  public static IEnumerable<object[]> GetUserCollections()
+  {
+    yield return
+    [
+      User1.username, User1.password,
+      SubNode1
+    ];
+    yield return
+    [
+      User2.username, User2.password,
+      SubNode2
+    ];
   }
 }

--- a/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
+++ b/tests/Hutch.Relay.Tests/Auth/UserCollectionsFixture.cs
@@ -21,12 +21,12 @@ public class UserCollectionsFixture
     yield return
     [
       User1.username, User1.password,
-      SubNode1.ToString()
+      SubNode1
     ];
     yield return
     [
       User2.username, User2.password,
-      SubNode2.ToString()
+      SubNode2
     ];
   }
 
@@ -60,7 +60,7 @@ public class UserCollectionsFixture
     users[0].PasswordHash = hasher.HashPassword(users[0], User1.password);
     users[1].PasswordHash = hasher.HashPassword(users[1], User2.password);
 
-    Database.RelayUsers.AddRange(users);
+    // Database.RelayUsers.AddRange(users);
 
     Database.SubNodes.AddRange(
       new()


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description

The mechanism by which we load "Enable"-able config sections into Feature Management was only working when `Enable` state was explicitly specified in config.

The main effect of this was that the intended default state of `UpstreamTaskApi` being enabled did not occur, and so in prior `1.1.0` alpha releases `UpstreamTaskApi` was in fact disabled by default.

This PR fixes that, as well as ensuring all Feature loading from config sections correctly binds OptionsModels (and therefore sets default values of `Enable` and other settings correctly).

This PR also fixes some issues with auth unit tests which were running unreliably locally.

## ✅ Added/updated tests?
- [x] This PR contains relevant tests / Or doesn't need to per the below explanation
