### PR TITLE
Add Beacon configuration endpoint

### DIFF
--- a/app/Hutch.Relay/Config/Beacon/BaseBeaconOptions.cs
+++ b/app/Hutch.Relay/Config/Beacon/BaseBeaconOptions.cs
@@ -11,13 +11,13 @@ public class BaseBeaconOptions
 
 public class MaturityAttributes
 {
-  public ProductionStatus ProductionStatus { get; set; }
+  public ProductionStatus ProductionStatus { get; set; } = ProductionStatus.DEV;
 }
 
 public class SecurityAttributes
 {
-  public Granularity DefaultGranularity { get; set; }
-  public List<ApiSecurityLevels> SecurityLevels { get; set; } = [];
+  public Granularity DefaultGranularity { get; set; } = Granularity.boolean;
+  public List<ApiSecurityLevels> SecurityLevels { get; set; } = [ApiSecurityLevels.PUBLIC];
 }
 
 public enum ProductionStatus
@@ -33,7 +33,7 @@ public enum ApiSecurityLevels
   /// Any anonymous user can read the data
   /// </summary>
   PUBLIC,
-  
+
   // Currently unsupported by Relay
   //REGISTERED	Only known users can read the data
   //CONTROLLED	Only specifically granted users can read the data
@@ -45,12 +45,12 @@ public enum Granularity
   /// returns 'true/false' responses
   /// </summary>
   boolean,
-  
+
   /// <summary>
   /// adds the total number of positive results found
   /// </summary>
   count,
-  
+
   // Unsupported by Relay
   // returns details for every document
   //Record

--- a/app/Hutch.Relay/Controllers/Beacon/InfoController.cs
+++ b/app/Hutch.Relay/Controllers/Beacon/InfoController.cs
@@ -1,3 +1,4 @@
+using Flurl.Util;
 using Hutch.Relay.Config;
 using Hutch.Relay.Config.Beacon;
 using Hutch.Relay.Constants;
@@ -143,6 +144,30 @@ public class InfoController(
             }
           }
         }
+      }
+    };
+  }
+
+  [HttpGet("configuration")]
+  public ConfigurationResponse GetBeaconConfiguration()
+  {
+    return new()
+    {
+      Meta = new()
+      {
+        BeaconId = _options.Info.Id,
+        ReturnedSchemas = {
+          new() {
+            EntityType = "map",
+            Schema = "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconConfigurationResponse.json"
+          }
+        }
+      },
+      Response = new()
+      {
+        MaturityAttributes = _options.MaturityAttributes,
+        SecurityAttributes = _options.SecurityAttributes,
+        EntryTypes = GetEntryTypes().Response.EntryTypes
       }
     };
   }

--- a/app/Hutch.Relay/Models/Beacon/ConfigurationResponse.cs
+++ b/app/Hutch.Relay/Models/Beacon/ConfigurationResponse.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+using Hutch.Relay.Config.Beacon;
+
+namespace Hutch.Relay.Models.Beacon;
+
+public class ConfigurationResponse
+{
+  public required InfoMeta Meta { get; set; }
+
+  public required ConfigurationResponseBody Response { get; set; }
+}
+
+public class ConfigurationResponseBody
+{
+  [JsonPropertyName("$schema")]
+  public string Schema { get; } = "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconConfigurationResponse.json";
+
+  public required MaturityAttributes MaturityAttributes { get; set; }
+  
+  public required SecurityAttributes SecurityAttributes { get; set; }
+
+  public required Dictionary<string, EntryTypeInfo> EntryTypes { get; set; }
+}


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description
This PR adds the GA4GH Beacon Configuration informational endpoint at `/ga4gh/beacon/v2/configuration`

It reports `MaturityAttributes` and `SecurityAttributes` per the spec and configured from the same sections within Relay's `Beacon` configuration section.

EntryTypes is populated the same as the EntryTypes endpoint, based on Relay's capabilities.

## Related Issues or other material
Closes #112