### PR TITLE
Added existence check on Relay Task creation during Enqueue

### DIFF
--- a/app/Hutch.Relay/Services/DownstreamTaskService.cs
+++ b/app/Hutch.Relay/Services/DownstreamTaskService.cs
@@ -33,6 +33,15 @@ public class DownstreamTaskService(
       return;
     }
 
+    // Skip if this task has already been enqueued (e.g. poller restarted mid-processing or short poll interval)
+    try
+    {
+      await relayTasks.Get(task.Uuid);
+      logger.LogInformation("Task {Id} already exists, skipping.", task.Uuid);
+      return;
+    }
+    catch (KeyNotFoundException) { }
+
     var relayTask = await relayTasks.Create(new()
     {
       Id = task.Uuid,


### PR DESCRIPTION
|-|
🦋 Bug Fix

## PR Description
Added existence check to `DownstreamTaskService.Enqueue` to ensure the relay task does not already exist before creation


## Related Issues or other material
Related: https://github.com/Health-Informatics-UoN/hutch-relay/issues/144
Closes: https://github.com/Health-Informatics-UoN/hutch-relay/issues/144

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
I haven't added unit tests
